### PR TITLE
Initial implementation of read-only buffer access to raw tables

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2015-03-10  Camille Scott  <camille.scott.w@gmail.com>
+
+   * lib/counting.hh, khmer/_khmermodule.cc: Expose the raw tables of
+   count-min sketches to the world of python using a buffer interface.
+   * tests/test_counting_hash.py: Tests of the above functionality.
+
 2015-03-08  Michael R. Crusoe  <mcrusoe@msu.edu>
 
    * Makefile: make 'pep8' target be more verbose

--- a/khmer/_khmermodule.cc
+++ b/khmer/_khmermodule.cc
@@ -694,8 +694,9 @@ hash_get_raw_tables(khmer_KCountingHash_Object * self, PyObject * args)
     PyObject * raw_tables = PyList_New(sizes.size());
     for (unsigned int i=0; i<sizes.size(); ++i) {
         PyObject * buf = PyBuffer_FromMemory(table_ptrs[i], sizes[i]);
-        if(!PyBuffer_Check(buf))
+        if(!PyBuffer_Check(buf)) {
             return NULL;
+        }
         PyList_SET_ITEM(raw_tables, i, buf);
     }
 
@@ -1552,8 +1553,9 @@ static PyMethodDef khmer_counting_methods[] = {
     },
     { "output_fasta_kmer_pos_freq", (PyCFunction)hash_output_fasta_kmer_pos_freq, METH_VARARGS, "" },
     { "get", (PyCFunction)hash_get, METH_VARARGS, "Get the count for the given k-mer" },
-    { "get_raw_tables", (PyCFunction)hash_get_raw_tables,
-       METH_VARARGS, "Get a list of the raw tables as memoryview objects"
+    {
+        "get_raw_tables", (PyCFunction)hash_get_raw_tables,
+        METH_VARARGS, "Get a list of the raw tables as memoryview objects"
     },
     { "get_min_count", (PyCFunction)hash_get_min_count, METH_VARARGS, "Get the smallest count of all the k-mers in the string" },
     { "get_max_count", (PyCFunction)hash_get_max_count, METH_VARARGS, "Get the largest count of all the k-mers in the string" },

--- a/khmer/_khmermodule.cc
+++ b/khmer/_khmermodule.cc
@@ -693,24 +693,10 @@ hash_get_raw_tables(khmer_KCountingHash_Object * self, PyObject * args)
 
     PyObject * raw_tables = PyList_New(sizes.size());
     for (unsigned int i=0; i<sizes.size(); ++i) {
-        /*
-        Py_buffer * buf = (Py_buffer * ) table_ptrs[i];
-        buf->obj = NULL;
-        buf->len = sizes[i];
-        buf->readonly = 1;
-        buf->ndim = 1;
-        buf->format = NULL;
-        buf->shape = NULL;
-        buf->strides = NULL;
-        buf->suboffsets = NULL;
-        buf->internal = NULL;
-        bufs.push_back(buf);
-        */
         PyObject * buf = PyBuffer_FromMemory(table_ptrs[i], sizes[i]);
         if(!PyBuffer_Check(buf))
             return NULL;
         PyList_SET_ITEM(raw_tables, i, buf);
-        //Py_XDECREF(buf);
     }
 
     return raw_tables;

--- a/khmer/_khmermodule.cc
+++ b/khmer/_khmermodule.cc
@@ -684,6 +684,40 @@ hash_abundance_distribution_with_reads_parser(khmer_KCountingHash_Object * me,
 
 static
 PyObject *
+hash_get_raw_tables(khmer_KCountingHash_Object * self, PyObject * args)
+{
+    CountingHash * counting = self->counting;
+
+    Byte ** table_ptrs = counting->get_raw_tables();
+    std::vector<HashIntoType> sizes = counting->get_tablesizes();
+
+    PyObject * raw_tables = PyList_New(sizes.size());
+    for (unsigned int i=0; i<sizes.size(); ++i) {
+        /*
+        Py_buffer * buf = (Py_buffer * ) table_ptrs[i];
+        buf->obj = NULL;
+        buf->len = sizes[i];
+        buf->readonly = 1;
+        buf->ndim = 1;
+        buf->format = NULL;
+        buf->shape = NULL;
+        buf->strides = NULL;
+        buf->suboffsets = NULL;
+        buf->internal = NULL;
+        bufs.push_back(buf);
+        */
+        PyObject * buf = PyBuffer_FromMemory(table_ptrs[i], sizes[i]);
+        if(!PyBuffer_Check(buf))
+            return NULL;
+        PyList_SET_ITEM(raw_tables, i, buf);
+        //Py_XDECREF(buf);
+    }
+
+    return raw_tables;
+}
+
+static
+PyObject *
 hash_set_use_bigcount(khmer_KCountingHash_Object * me, PyObject * args)
 {
     CountingHash * counting = me->counting;
@@ -1532,6 +1566,9 @@ static PyMethodDef khmer_counting_methods[] = {
     },
     { "output_fasta_kmer_pos_freq", (PyCFunction)hash_output_fasta_kmer_pos_freq, METH_VARARGS, "" },
     { "get", (PyCFunction)hash_get, METH_VARARGS, "Get the count for the given k-mer" },
+    { "get_raw_tables", (PyCFunction)hash_get_raw_tables,
+       METH_VARARGS, "Get a list of the raw tables as memoryview objects"
+    },
     { "get_min_count", (PyCFunction)hash_get_min_count, METH_VARARGS, "Get the smallest count of all the k-mers in the string" },
     { "get_max_count", (PyCFunction)hash_get_max_count, METH_VARARGS, "Get the largest count of all the k-mers in the string" },
     { "get_median_count", (PyCFunction)hash_get_median_count, METH_VARARGS, "Get the median, average, and stddev of the k-mer counts in the string" },

--- a/lib/counting.hh
+++ b/lib/counting.hh
@@ -87,6 +87,12 @@ public:
         }
     }
 
+    // Writing to the tables outside of defined methods has undefined behavior!
+    // As such, this should only be used to return read-only interfaces
+    Byte ** get_raw_tables() {
+        return _counts;
+    }
+
     virtual BoundedCounterType test_and_set_bits(const char * kmer)
     {
         BoundedCounterType x = get_count(kmer); // @CTB just hash it, yo.

--- a/lib/counting.hh
+++ b/lib/counting.hh
@@ -89,7 +89,8 @@ public:
 
     // Writing to the tables outside of defined methods has undefined behavior!
     // As such, this should only be used to return read-only interfaces
-    Byte ** get_raw_tables() {
+    Byte ** get_raw_tables()
+    {
         return _counts;
     }
 

--- a/tests/test_counting_hash.py
+++ b/tests/test_counting_hash.py
@@ -113,13 +113,13 @@ def test_get_raw_tables():
 def test_get_raw_tables_view():
     ht = khmer.new_counting_hash(20, 1e5, 4)
     tables = ht.get_raw_tables()
-    for t in tables:
-        m = memoryview(t)
-        assert sum(m.tolist()) == 0
+    for tab in tables:
+        memv = memoryview(tab)
+        assert sum(memv.tolist()) == 0
     ht.consume('AAAATTTTCCCCGGGGAAAA')
-    for t in tables:
-        m = memoryview(t)
-        assert sum(m.tolist()) == 1
+    for tab in tables:
+        memv = memoryview(tab)
+        assert sum(memv.tolist()) == 1
 
 
 @attr('linux')

--- a/tests/test_counting_hash.py
+++ b/tests/test_counting_hash.py
@@ -100,6 +100,25 @@ class Test_CountingHash(object):
 
         assert hi.get(GG) == 2
 
+def test_get_raw_tables():
+    ht = khmer.new_counting_hash(20, 1e5, 4)
+    tables = ht.get_raw_tables()
+
+    for size, table in zip(ht.hashsizes(), tables):
+        assert type(table) is buffer
+        assert size == len(table)
+
+def test_get_raw_tables_view():
+    ht = khmer.new_counting_hash(20, 1e5, 4)
+    tables = ht.get_raw_tables()
+    for t in tables:
+        m = memoryview(t)
+        assert sum(m.tolist()) == 0
+    ht.consume('AAAATTTTCCCCGGGGAAAA')
+    for t in tables:
+        m = memoryview(t)
+        assert sum(m.tolist()) == 1
+
 
 @attr('linux')
 def test_toobig():

--- a/tests/test_counting_hash.py
+++ b/tests/test_counting_hash.py
@@ -100,13 +100,15 @@ class Test_CountingHash(object):
 
         assert hi.get(GG) == 2
 
+
 def test_get_raw_tables():
     ht = khmer.new_counting_hash(20, 1e5, 4)
     tables = ht.get_raw_tables()
 
     for size, table in zip(ht.hashsizes(), tables):
-        assert type(table) is buffer
+        assert isinstance(table, buffer)
         assert size == len(table)
+
 
 def test_get_raw_tables_view():
     ht = khmer.new_counting_hash(20, 1e5, 4)


### PR DESCRIPTION
This addresses #667: exposes the tables as a read-only buffer object. I've chosen read-only as there will be undefined behavior from writing directly to the tables outside of the `count` functions; of course, the idea is that you can still use the python-exposed hashtable object as you see fit, and the buffer view will update to reflect that.

For now, I've just exported a list of `N` buffers. Eventually I'd like this to properly define the buffer interface on the hashtable type object, exposing a single buffer or memoryview object with proper striding / offsets for the `N` dimension array, but... :effort:.

Some example usage:

```
In [1]: import khmer

In [2]: import numpy as np

In [3]: ht = khmer.new_counting_hash (20, 1e8, 4)

In [4]: tables = ht.get_raw_tables ()

In [5]: tables[0]
Out[5]: <read-only buffer ptr 0x7ff6a7015010, size 100000007 at 0x7ff6acff2930>

In [6]: arr = np.frombuffer (tables[0], dtype=np.uint8)

In [7]: arr
Out[7]: array([0, 0, 0, ..., 0, 0, 0], dtype=uint8)

In [8]: arr.sum()
Out[8]: 0

In [9]: ht.consume_fasta('tests/test-data/test-reads.fa')
Out[9]: (25000, 1425000L)

In [10]: arr.sum()
Out[10]: 1424408
```