### PR TITLE
Fix Issue 669: Check that output and info files in load-into-counting.py are writable before loading input

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2014-11-26  Phillip Garland  <pgarland@gmail.com>
+
+	* khmer/file.py (check_file_writable): New function.
+
+	* scripts/load-into-counting.py (main): check if output and info
+	files are writable.
+
 2014-11-23  Phillip Garland  <pgarland@gmail.com>
 
 	* lib/khmer.hh (khmer): define KSIZE_MAX

--- a/khmer/file.py
+++ b/khmer/file.py
@@ -40,16 +40,16 @@ def check_file_status(file_path):
 def check_file_writable(file_path):
     """Returns if file_path is writable, exits out if it's not"""
     try:
-        f = open(file_path, "a")
-    except IOError as e:
-        if e.errno == errno.EACCES:
+        file_obj = open(file_path, "a")
+    except IOError as error:
+        if error.errno == errno.EACCES:
             print >>sys.stderr, "ERROR: File %s does not have write " \
                 % file_path + "permission; exiting"
             sys.exit(1)
         else:
-            print >>sys.stderr, "ERROR: " + e.strerror
+            print >>sys.stderr, "ERROR: " + error.strerror
     else:
-        f.close()
+        file_obj.close()
         return
 
 

--- a/khmer/file.py
+++ b/khmer/file.py
@@ -11,8 +11,8 @@ File handling/checking utilities for command-line scripts.
 
 import os
 import sys
+import errno
 from stat import S_ISBLK, S_ISFIFO
-
 
 def check_file_status(file_path):
     """Check the status of the file; if the file is empty or doesn't exist
@@ -36,6 +36,22 @@ def check_file_status(file_path):
             sys.exit(1)
 
 
+def check_file_writable(file_path):
+    """Returns if file_path is writable, exits out if it's not"""
+    try:
+        f = open(file_path, "a")
+    except IOError as e:
+        if e.errno == errno.EACCES:
+            print >>sys.stderr, "ERROR: File %s does not have write " \
+                % file_path + "permission; exiting"
+            sys.exit(1)
+        else:
+            print >>sys.stderr, "ERROR: " + e.strerror
+    else:
+        f.close()
+        return
+
+   
 def check_space(in_files, _testhook_free_space=None):
     """
     Estimate size of input files passed, then calculate

--- a/khmer/file.py
+++ b/khmer/file.py
@@ -14,6 +14,7 @@ import sys
 import errno
 from stat import S_ISBLK, S_ISFIFO
 
+
 def check_file_status(file_path):
     """Check the status of the file; if the file is empty or doesn't exist
     AND if the file is NOT a fifo/block/named pipe then a warning is printed
@@ -51,7 +52,7 @@ def check_file_writable(file_path):
         f.close()
         return
 
-   
+
 def check_space(in_files, _testhook_free_space=None):
     """
     Estimate size of input files passed, then calculate

--- a/scripts/load-into-counting.py
+++ b/scripts/load-into-counting.py
@@ -21,6 +21,7 @@ from khmer.khmer_args import build_counting_args, report_on_config, info,\
     add_threading_args
 from khmer.file import check_file_status, check_space
 from khmer.file import check_space_for_hashtable
+from khmer.file import check_file_writable
 
 
 def get_parser():
@@ -74,6 +75,9 @@ def main():
     check_space(args.input_sequence_filename)
     check_space_for_hashtable(args.n_tables * args.min_tablesize)
 
+    check_file_writable(base)
+    check_file_writable(base + ".info")
+    
     print >>sys.stderr, 'Saving k-mer counting table to %s' % base
     print >>sys.stderr, 'Loading kmers from sequences in %s' % repr(filenames)
 

--- a/scripts/load-into-counting.py
+++ b/scripts/load-into-counting.py
@@ -77,7 +77,7 @@ def main():
 
     check_file_writable(base)
     check_file_writable(base + ".info")
-    
+
     print >>sys.stderr, 'Saving k-mer counting table to %s' % base
     print >>sys.stderr, 'Loading kmers from sequences in %s' % repr(filenames)
 


### PR DESCRIPTION
- [x] Is it mergable?
- [x] Did it pass the tests?
- [ ] If it introduces new functionality in scripts/ is it tested?
  Check for code coverage.
- [x] Is it well formatted? Look at `make pep8`, `make diff_pylint_report`,
  `make cppcheck`, and `make doc` output. Use `make format` and manual fixing as needed.
- [x] Is it documented in the ChangeLog?
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?