### PR TITLE
HLL coverage improvements

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,12 @@
 2015-02-24  Luiz Irber  <irberlui@msu.edu>
 
+    * khmer/_khmermodule.cc: expose HLL internals as read-only attributes.
+    * lib/hllcounter.{cc,hh}: simplify error checking, add getters for HLL.
+    * tests/test_hll.py: add test cases for increasing coverage, also fix
+    some of the previous ones using the new HLL read-only attributes.
+
+2015-02-24  Luiz Irber  <irberlui@msu.edu>
+
    * khmer/_khmermodule.cc: Fix coding style violations.
 
 2015-02-24  Luiz Irber  <irberlui@msu.edu>

--- a/khmer/__init__.py
+++ b/khmer/__init__.py
@@ -253,6 +253,20 @@ class Hashbits(_Hashbits):
 
 
 class HLLCounter(_HLLCounter):
+    """
+    A HyperLogLog counter is a probabilistic data structure specialized on
+    cardinality estimation.
+    There is a precision/memory consumption trade-off: error rate determines
+    how much memory is consumed.
+
+    # Creating a new HLLCounter:
+
+    >>> khmer.HLLCounter(error_rate, ksize)
+
+    where the default values are:
+      - error_rate: 0.01
+      - ksize: 20
+    """
 
     def __len__(self):
         return self.estimate_cardinality()

--- a/khmer/_khmermodule.cc
+++ b/khmer/_khmermodule.cc
@@ -4455,6 +4455,27 @@ static PyObject * hllcounter_consume_fasta(khmer_KHLLCounter_Object * me,
     return Py_BuildValue("IK", total_reads, n_consumed);
 }
 
+static
+PyObject *
+hllcounter_getp(khmer_KHLLCounter_Object * me)
+{
+    return PyLong_FromLong(me->hllcounter->get_p());
+}
+
+static
+PyObject *
+hllcounter_getm(khmer_KHLLCounter_Object * me)
+{
+    return PyLong_FromLong(me->hllcounter->get_m());
+}
+
+static
+PyObject *
+hllcounter_getalpha(khmer_KHLLCounter_Object * me)
+{
+    return PyFloat_FromDouble(me->hllcounter->get_alpha());
+}
+
 static PyMethodDef khmer_hllcounter_methods[] = {
     {
         "add", (PyCFunction)hllcounter_add,
@@ -4476,6 +4497,28 @@ static PyMethodDef khmer_hllcounter_methods[] = {
         METH_VARARGS,
         "Read sequences from file, break into k-mers, "
         "and add each k-mer to the counter."
+    },
+    {NULL} /* Sentinel */
+};
+
+static PyGetSetDef khmer_hllcounter_getseters[] = {
+    {
+        "alpha",
+        (getter)hllcounter_getalpha, NULL,
+        "alpha constant for the current counter.",
+        NULL
+    },
+    {
+        "p",
+        (getter)hllcounter_getp, NULL,
+        "p for the current counter. The number of registers m is 2 ** p",
+        NULL
+    },
+    {
+        "m",
+        (getter)hllcounter_getm, NULL,
+        "Get the number of registers for the current counter.",
+        NULL
     },
     {NULL} /* Sentinel */
 };
@@ -4510,7 +4553,7 @@ static PyTypeObject khmer_KHLLCounter_Type = {
     0,                                         /* tp_iternext */
     khmer_hllcounter_methods,                  /* tp_methods */
     0,                                         /* tp_members */
-    0,                                         /* tp_getset */
+    khmer_hllcounter_getseters,                /* tp_getset */
     0,                                         /* tp_base */
     0,                                         /* tp_dict */
     0,                                         /* tp_descr_get */

--- a/khmer/_khmermodule.cc
+++ b/khmer/_khmermodule.cc
@@ -4580,31 +4580,31 @@ static PyMethodDef khmer_hllcounter_methods[] = {
 
 static PyGetSetDef khmer_hllcounter_getseters[] = {
     {
-        "alpha",
+        (char *)"alpha",
         (getter)hllcounter_getalpha, NULL,
-        "alpha constant for this HLL counter.",
+        (char *)"alpha constant for this HLL counter.",
         NULL
     },
     {
-        "error_rate",
+        (char *)"error_rate",
         (getter)hllcounter_get_erate, (setter)hllcounter_set_erate,
-        "Error rate for this HLL counter. "
+        (char *)"Error rate for this HLL counter. "
         "Can be changed prior to first counting, but becomes read-only after "
         "that (raising AttributeError)",
         NULL
     },
     {
-        "ksize",
+        (char *)"ksize",
         (getter)hllcounter_get_ksize, (setter)hllcounter_set_ksize,
-        "k-mer size for this HLL counter."
+        (char *)"k-mer size for this HLL counter."
         "Can be changed prior to first counting, but becomes read-only after "
         "that (raising AttributeError)",
         NULL
     },
     {
-        "counters",
+        (char *)"counters",
         (getter)hllcounter_getcounters, NULL,
-        "Read-only internal counters. len(counters) == m == 2 ** p",
+        (char *)"Read-only internal counters.",
         NULL
     },
     {NULL} /* Sentinel */

--- a/khmer/_khmermodule.cc
+++ b/khmer/_khmermodule.cc
@@ -4491,9 +4491,6 @@ hllcounter_set_ksize(khmer_KHLLCounter_Object * me, PyObject *value,
 
     try {
         me->hllcounter->set_ksize(ksize);
-    } catch (InvalidValue &e) {
-        PyErr_SetString(PyExc_ValueError, e.what());
-        return -1;
     } catch (ReadOnlyAttribute &e) {
         PyErr_SetString(PyExc_AttributeError, e.what());
         return -1;

--- a/khmer/_khmermodule.cc
+++ b/khmer/_khmermodule.cc
@@ -4472,13 +4472,23 @@ hllcounter_set_ksize(khmer_KHLLCounter_Object * me, PyObject *value,
         return -1;
     }
 
-    if (!PyLong_Check(value) && !PyInt_Check(value)) {
+    long ksize = 0;
+    if (PyLong_Check(value)) {
+        ksize = PyLong_AsLong(value);
+    } else if (PyInt_Check(value)) {
+        ksize = PyInt_AsLong(value);
+    } else {
         PyErr_SetString(PyExc_TypeError,
-                        "Please use an int value for k-mer size");
+                        "Please use an integer value for k-mer size");
         return -1;
     }
 
-    WordLength ksize = PyLong_AsLong(value);
+    if (ksize <= 0) {
+        PyErr_SetString(PyExc_ValueError, "Please set k-mer size to a value "
+                        "greater than zero");
+        return -1;
+    }
+
     try {
         me->hllcounter->set_ksize(ksize);
     } catch (InvalidValue &e) {

--- a/khmer/_khmermodule.cc
+++ b/khmer/_khmermodule.cc
@@ -4469,6 +4469,20 @@ hllcounter_getalpha(khmer_KHLLCounter_Object * me)
     return PyFloat_FromDouble(me->hllcounter->get_alpha());
 }
 
+static
+PyObject *
+hllcounter_getcounters(khmer_KHLLCounter_Object * me)
+{
+    std::vector<int> counters = me->hllcounter->get_M();
+
+    PyObject * x = PyList_New(counters.size());
+    for (size_t i = 0; i < counters.size(); i++) {
+        PyList_SET_ITEM(x, i, PyLong_FromLong(counters[i]));
+    }
+
+    return x;
+}
+
 static PyMethodDef khmer_hllcounter_methods[] = {
     {
         "add", (PyCFunction)hllcounter_add,
@@ -4510,7 +4524,13 @@ static PyGetSetDef khmer_hllcounter_getseters[] = {
     {
         "m",
         (getter)hllcounter_getm, NULL,
-        "Get the number of registers for the current counter.",
+        "Number of registers for the current counter.",
+        NULL
+    },
+    {
+        "counters",
+        (getter)hllcounter_getcounters, NULL,
+        "Counters. len(counters) == m == 2 ** p",
         NULL
     },
     {NULL} /* Sentinel */

--- a/khmer/_khmermodule.cc
+++ b/khmer/_khmermodule.cc
@@ -4347,13 +4347,6 @@ static PyObject* khmer_hllcounter_new(PyTypeObject * type, PyObject * args,
             return NULL;
         }
 
-        if ((error_rate < 0) || (error_rate > 1.0)) {
-            Py_DECREF(self);
-            PyErr_SetString(PyExc_ValueError,
-                            "Error rate should be between 0.0 and 1.0");
-            return NULL;
-        }
-
         try {
             self->hllcounter = new HLLCounter(error_rate, ksize);
         } catch (khmer_exception &e) {

--- a/khmer/_khmermodule.cc
+++ b/khmer/_khmermodule.cc
@@ -4512,25 +4512,25 @@ static PyGetSetDef khmer_hllcounter_getseters[] = {
     {
         "alpha",
         (getter)hllcounter_getalpha, NULL,
-        "alpha constant for the current counter.",
+        "alpha constant for this HLL counter.",
         NULL
     },
     {
         "p",
         (getter)hllcounter_getp, NULL,
-        "p for the current counter. The number of registers m is 2 ** p",
+        "p for this HLL counter. The number of internal counters m is 2 ** p",
         NULL
     },
     {
         "m",
         (getter)hllcounter_getm, NULL,
-        "Number of registers for the current counter.",
+        "Number of internal counters for this HLL counter.",
         NULL
     },
     {
         "counters",
         (getter)hllcounter_getcounters, NULL,
-        "Counters. len(counters) == m == 2 ** p",
+        "Read-only internal counters. len(counters) == m == 2 ** p",
         NULL
     },
     {NULL} /* Sentinel */

--- a/lib/hllcounter.cc
+++ b/lib/hllcounter.cc
@@ -34,18 +34,12 @@ std::map<int, std::vector<double> > biasData;
 
 double calc_alpha(const int p)
 {
-    if ((p < 4) or (p > 16)) {
-        double valid_lower_bound = 1.04 / std::sqrt(std::pow(static_cast<float>(2),
-                                   17));
-        double valid_upper_bound = 1.04 / std::sqrt(std::pow(static_cast<float>(2), 3));
-
-        std::stringstream message;
-        if (p < 4) {
-            message << "Max error should be smaller than " << valid_upper_bound;
-        } else {
-            message << "Min error should be greater than " << valid_lower_bound;
-        }
-        throw khmer_exception(message.str().c_str());
+    if (p < 4) {
+        // ceil(log2((1.04 / x) ^ 2)) = 4, solve for x
+        throw khmer_exception("Error rate must be smaller than 0.367696");
+    } else if (p > 16) {
+        // ceil(log2((1.04 / x) ^ 2)) = 16, solve for x
+        throw khmer_exception("Error rate must be greater than 0.0040624");
     }
 
     /*
@@ -237,6 +231,9 @@ int get_rho(HashIntoType w, int max_width)
 
 HLLCounter::HLLCounter(double error_rate, WordLength ksize)
 {
+    if (error_rate < 0) {
+        throw khmer_exception("Error rate should be a positive number");
+    }
     int p = ceil(log2(pow(1.04 / error_rate, 2)));
     this->init(p, ksize);
 }

--- a/lib/hllcounter.cc
+++ b/lib/hllcounter.cc
@@ -286,10 +286,6 @@ void HLLCounter::set_ksize(WordLength new_ksize)
                                 "first counting");
     }
 
-    if (new_ksize <= 0) {
-        throw InvalidValue("Please set k-mer size to a value "
-                           "greater than zero");
-    }
     this->init(this->p, new_ksize);
 }
 

--- a/lib/hllcounter.cc
+++ b/lib/hllcounter.cc
@@ -32,7 +32,7 @@ std::map<int, std::vector<double> > rawEstimateData;
 std::map<int, std::vector<double> > biasData;
 
 
-double get_alpha(const int p)
+double calc_alpha(const int p)
 {
     if ((p < 4) or (p > 16)) {
         double valid_lower_bound = 1.04 / std::sqrt(std::pow(static_cast<float>(2),
@@ -248,7 +248,7 @@ HLLCounter::HLLCounter(int p, WordLength ksize)
 
 void HLLCounter::init(int p, WordLength ksize)
 {
-    this->alpha = get_alpha(p);
+    this->alpha = calc_alpha(p);
     this->p = p;
     this->_ksize = ksize;
     this->m = 1 << p;

--- a/lib/hllcounter.hh
+++ b/lib/hllcounter.hh
@@ -50,10 +50,17 @@ public:
     {
         return m;
     }
+    void set_ksize(WordLength new_ksize);
+    int get_ksize()
+    {
+        return _ksize;
+    }
     std::vector<int> get_M()
     {
         return M;
     }
+    double get_erate();
+    void set_erate(double new_erate);
 private:
     double _Ep();
     double alpha;

--- a/lib/hllcounter.hh
+++ b/lib/hllcounter.hh
@@ -50,6 +50,10 @@ public:
     {
         return m;
     }
+    std::vector<int> get_M()
+    {
+        return M;
+    }
 private:
     double _Ep();
     double alpha;

--- a/lib/hllcounter.hh
+++ b/lib/hllcounter.hh
@@ -37,6 +37,19 @@ public:
     HashIntoType estimate_cardinality();
     void merge(HLLCounter &);
     virtual ~HLLCounter() {}
+
+    double get_alpha()
+    {
+        return alpha;
+    }
+    int get_p()
+    {
+        return p;
+    }
+    int get_m()
+    {
+        return m;
+    }
 private:
     double _Ep();
     double alpha;

--- a/lib/khmer_exception.hh
+++ b/lib/khmer_exception.hh
@@ -66,6 +66,31 @@ public:
     StreamReadError(const char * msg) : khmer_file_exception(msg) {}
 };
 
+
+///
+// An exception for invalid arguments to functions
+//
+
+class InvalidValue : public khmer_exception
+{
+public:
+    explicit InvalidValue(const char * msg) : khmer_exception(msg) { }
+    explicit InvalidValue(const std::string& msg)
+        : khmer_exception(msg) { }
+};
+
+///
+// An exception for trying to change a read-only attributes
+//
+
+class ReadOnlyAttribute : public khmer_exception
+{
+public:
+    explicit ReadOnlyAttribute(const char * msg) : khmer_exception(msg) { }
+    explicit ReadOnlyAttribute(const std::string& msg)
+        : khmer_exception(msg) { }
+};
+
 }
 
 #endif // KHMER_EXCEPTION_HH

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ BZIP2DIR = 'third-party/bzip2'
 BUILD_DEPENDS = []
 BUILD_DEPENDS.extend(path_join("lib", bn + ".hh") for bn in [
     "khmer", "kmer_hash", "hashtable", "counting", "hashbits", "labelhash",
-    "hllcounter"])
+    "hllcounter", "khmer_exception", "read_aligner", "subset", "read_parsers"])
 
 SOURCES = ["khmer/_khmermodule.cc"]
 SOURCES.extend(path_join("lib", bn + ".cc") for bn in [

--- a/tests/test_hll.py
+++ b/tests/test_hll.py
@@ -83,6 +83,32 @@ def test_hll_consume_fasta():
     assert abs(1 - float(hllcpp.estimate_cardinality()) / N_UNIQUE) < ERR_RATE
 
 
+def test_hll_consume_fasta_ep():
+    # During estimation trigger the _Ep() method,
+    # we need all internal counters values to be different than zero for this.
+
+    filename = utils.get_test_data('paired-mixed.fa')
+    hll = khmer.HLLCounter(0.36, 32)
+    hll.consume_fasta(filename)
+
+    assert all(c != 0 for c in hll.counters)
+    assert len(hll) == 236
+
+
+def test_hll_consume_fasta_estimate_bias():
+    # During estimation trigger the estimate_bias method,
+    # we need all internal counters values to be different than zero for this,
+    # and also the cardinality should be small (if it is large we fall on the
+    # default case).
+
+    filename = utils.get_test_data("test-abund-read-3.fa")
+    hll = khmer.HLLCounter(0.36, K)
+    hll.consume_fasta(filename)
+
+    assert all(c != 0 for c in hll.counters)
+    assert len(hll) == 79
+
+
 def test_hll_len():
     filename = utils.get_test_data('random-20-a.fa')
     hllcpp = khmer.HLLCounter(ERR_RATE, K)
@@ -174,3 +200,10 @@ def test_hll_error_rate_min():
 
     hllcpp = khmer.HLLCounter(0.0040625, K)
     assert hllcpp.p == 16
+
+
+def test_hll_get_counters():
+    hll = khmer.HLLCounter(0.36, K)
+    counters = hll.counters
+    assert len(counters) == hll.m
+    assert all(c == 0 for c in counters)

--- a/tests/test_hll.py
+++ b/tests/test_hll.py
@@ -97,6 +97,41 @@ def test_hll_empty():
     assert len(hllcpp) == 0
 
 
+@raises(AttributeError)
+def test_hll_readonly_alpha():
+    hllcpp = khmer.HLLCounter(ERR_RATE, K)
+    hllcpp.alpha = 5
+
+
+@raises(AttributeError)
+def test_hll_readonly_p():
+    hllcpp = khmer.HLLCounter(ERR_RATE, K)
+    hllcpp.p = 5
+
+
+@raises(AttributeError)
+def test_hll_readonly_m():
+    hllcpp = khmer.HLLCounter(ERR_RATE, K)
+    hllcpp.m = 5
+
+
+def test_hll_cover_calc_alpha():
+    hllcpp = khmer.HLLCounter(0.36, K)
+    assert hllcpp.alpha == 0.673
+    assert hllcpp.p == 4
+    assert hllcpp.m == 16
+
+    hllcpp = khmer.HLLCounter(0.21, K)
+    assert hllcpp.alpha == 0.697
+    assert hllcpp.p == 5
+    assert hllcpp.m == 32
+
+    hllcpp = khmer.HLLCounter(0.16, K)
+    assert hllcpp.alpha == 0.709
+    assert hllcpp.p == 6
+    assert hllcpp.m == 64
+
+
 @raises(ValueError)
 def test_hll_invalid_base():
     # this test should raise a ValueError,
@@ -117,11 +152,25 @@ def test_hll_invalid_error_rate():
 def test_hll_invalid_error_rate_max():
     # test if error_rate is a valid value
 
-    hllcpp = khmer.HLLCounter(0.5, K)
+    hllcpp = khmer.HLLCounter(0.367696, K)
+
+
+def test_hll_error_rate_max():
+    # test if error_rate is a valid value
+
+    hllcpp = khmer.HLLCounter(0.367695, K)
+    assert hllcpp.p == 4
 
 
 @raises(ValueError)
 def test_hll_invalid_error_rate_min():
     # test if error_rate is a valid value
 
-    hllcpp = khmer.HLLCounter(0.000001, K)
+    hllcpp = khmer.HLLCounter(0.0040624, K)
+
+
+def test_hll_error_rate_min():
+    # test if error_rate is a valid value
+
+    hllcpp = khmer.HLLCounter(0.0040625, K)
+    assert hllcpp.p == 16

--- a/tests/test_hll.py
+++ b/tests/test_hll.py
@@ -209,6 +209,9 @@ def test_hll_change_error_rate():
     with assert_raises(ValueError):
         hllcpp.error_rate = 2.5
 
+    with assert_raises(ValueError):
+        hllcpp.error_rate = -10.
+
     # error rate can only be changed prior to first counting,
     hllcpp.consume_string('AAACCACTTGTGCATGTCAGTGCAGTCAGT')
     with assert_raises(AttributeError):
@@ -219,7 +222,10 @@ def test_hll_change_ksize():
     hllcpp = khmer.HLLCounter(0.0040625, K)
     assert hllcpp.ksize == K
 
-    hllcpp.ksize = 12
+    hllcpp.ksize = 24
+    assert hllcpp.ksize == 24
+
+    hllcpp.ksize = 12L
     assert hllcpp.ksize == 12
 
     with assert_raises(ValueError):

--- a/tests/test_hll.py
+++ b/tests/test_hll.py
@@ -200,6 +200,15 @@ def test_hll_change_error_rate():
     hllcpp.error_rate = 0.01
     assert hllcpp.error_rate == 0.008125
 
+    with assert_raises(TypeError):
+        del hllcpp.error_rate
+
+    with assert_raises(TypeError):
+        hllcpp.error_rate = 5
+
+    with assert_raises(ValueError):
+        hllcpp.error_rate = 2.5
+
     # error rate can only be changed prior to first counting,
     hllcpp.consume_string('AAACCACTTGTGCATGTCAGTGCAGTCAGT')
     with assert_raises(AttributeError):
@@ -212,6 +221,15 @@ def test_hll_change_ksize():
 
     hllcpp.ksize = 12
     assert hllcpp.ksize == 12
+
+    with assert_raises(ValueError):
+        hllcpp.ksize = -20
+
+    with assert_raises(TypeError):
+        del hllcpp.ksize
+
+    with assert_raises(TypeError):
+        hllcpp.ksize = 33.4
 
     # error rate can only be changed prior to first counting,
     hllcpp.consume_string('AAACCACTTGTGCATGTCAGTGCAGTCAGT')

--- a/tests/test_hll.py
+++ b/tests/test_hll.py
@@ -9,13 +9,10 @@
 import string
 
 import khmer
-from khmer import ReadParser
 
 from screed.fasta import fasta_iter
-import screed
 
 import khmer_tst_utils as utils
-from nose.plugins.attrib import attr
 from nose.tools import raises
 
 
@@ -69,6 +66,13 @@ def test_hll_consume_string():
     assert abs(1 - float(hllcpp.estimate_cardinality()) / N_UNIQUE) < ERR_RATE
 
 
+@raises(IOError)
+def test_hll_empty_fasta():
+    filename = utils.get_test_data('test-empty.fa')
+    hll = khmer.HLLCounter(ERR_RATE, K)
+    hll.consume_fasta(filename)
+
+
 def test_hll_consume_fasta():
     # test c++ code to count unique kmers using HyperLogLog
 
@@ -85,6 +89,12 @@ def test_hll_len():
     hllcpp.consume_fasta(filename)
 
     assert hllcpp.estimate_cardinality() == len(hllcpp)
+
+
+def test_hll_empty():
+    hllcpp = khmer.HLLCounter(ERR_RATE, K)
+
+    assert len(hllcpp) == 0
 
 
 @raises(ValueError)


### PR DESCRIPTION
## HLL coverage improvements

HyperLogLog line coverage is a bit low because some conditions during estimation are not so easy to trigger. After exposing the HLL internals it was easier to find test cases using data already available for the current tests.

This PR improves the coverage and also simplifies some error checking inside the HLL.

