### PR TITLE
Enable specification of output directory

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,7 @@
 2015-02-09  Bede Constantinides  <bede.constantinides@manchester.ac.uk>
 
    * scripts/split-paired-reads.py: added -o option to allow specification
-   of an outut directory
+   of an output directory
    * tests/test_scripts.py: added accompanying test for split-paired-reads.py
 
 2015-02-01  Titus Brown  <titus@idyll.org>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2015-02-09  Bede Constantinides  <bede.constantinides@manchester.ac.uk>
+
+   * scripts/split-paired-reads.py: added -o option to allow specification
+   of an outut directory
+   * tests/test_scripts.py: added accompanying test for split-paired-reads.py
+
 2015-02-01  Titus Brown  <titus@idyll.org>
 
    * khmer/_khmermodule.cc: added functions hash_find_all_tags_list and

--- a/scripts/split-paired-reads.py
+++ b/scripts/split-paired-reads.py
@@ -16,7 +16,7 @@ Reads FASTQ and FASTA input, retains format for output.
 """
 import screed
 import sys
-import os.path
+import os
 import textwrap
 import argparse
 import khmer
@@ -40,6 +40,10 @@ def get_parser():
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
     parser.add_argument('infile')
+    parser.add_argument('-o', '--output-dir', metavar="output_directory",
+                        dest='output_directory', default='', help='Output '
+                        'split reads to specified directory. Creates '
+                        'directory if necessary')
     parser.add_argument('--version', action='version', version='%(prog)s '
                         + khmer.__version__)
     parser.add_argument('-f', '--force', default=False, action='store_true',
@@ -57,8 +61,15 @@ def main():
     filenames = [infile]
     check_space(filenames, args.force)
 
-    out1 = os.path.basename(infile) + '.1'
-    out2 = os.path.basename(infile) + '.2'
+    if args.output_directory:
+        if not os.path.exists(args.output_directory):
+            os.makedirs(args.output_directory)
+        out1 = args.output_directory + '/' + os.path.basename(infile) + '.1'
+        out2 = args.output_directory + '/' + os.path.basename(infile) + '.2'
+    else:
+        out1 = os.path.basename(infile) + '.1'
+        out2 = os.path.basename(infile) + '.2'
+
     fp_out1 = open(out1, 'w')
     fp_out2 = open(out2, 'w')
 

--- a/scripts/split-paired-reads.py
+++ b/scripts/split-paired-reads.py
@@ -30,9 +30,17 @@ def get_parser():
     interleaved; other programs want input in the Insanely Bad Format, with
     left- and right- reads separated. This reformats the former to the latter.
 
+    The directory into which the left- and right- reads are output may be
+    specified using :option:`-o`/:option:`--output-dir`. This directory will be
+    created if it does not already exist.
+
     Example::
 
         split-paired-reads.py tests/test-data/paired.fq
+
+    Example::
+
+        split-paired-reads.py -o ~/reads-go-here tests/test-data/paired.fq
     """
     parser = argparse.ArgumentParser(
         description='Split interleaved reads into two files, left and right.',

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1549,13 +1549,13 @@ def test_split_paired_reads_3_output_dir():
 
     # actual output files...
     outfile1 = utils.get_temp_filename('paired.fq.1')
-    in_dir = os.path.dirname(outfile1)
-    outfile2 = utils.get_temp_filename('paired.fq.2', in_dir)
+    output_dir = os.path.dirname(outfile1)
+    outfile2 = utils.get_temp_filename('paired.fq.2', output_dir)
 
     script = scriptpath('split-paired-reads.py')
-    args = [infile, '--output-dir', in_dir]
+    args = [infile, '--output-dir', output_dir]
 
-    utils.runscript(script, args, in_dir)
+    utils.runscript(script, args)
 
     assert os.path.exists(outfile1), outfile1
     assert os.path.exists(outfile2), outfile2

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1540,6 +1540,43 @@ def test_split_paired_reads_2_fq():
     assert n > 0
 
 
+def test_split_paired_reads_3_output_dir():
+    # test input file
+    infile = utils.get_test_data('paired.fq')
+
+    ex_outfile1 = utils.get_test_data('paired.fq.1')
+    ex_outfile2 = utils.get_test_data('paired.fq.2')
+
+    # actual output files...
+    outfile1 = utils.get_temp_filename('paired.fq.1')
+    in_dir = os.path.dirname(outfile1)
+    outfile2 = utils.get_temp_filename('paired.fq.2', in_dir)
+
+    script = scriptpath('split-paired-reads.py')
+    args = [infile, '--output-dir', in_dir]
+
+    utils.runscript(script, args, in_dir)
+
+    assert os.path.exists(outfile1), outfile1
+    assert os.path.exists(outfile2), outfile2
+
+    n = 0
+    for r, q in zip(screed.open(ex_outfile1), screed.open(outfile1)):
+        n += 1
+        assert r.name == q.name
+        assert r.sequence == q.sequence
+        assert r.accuracy == q.accuracy
+    assert n > 0
+
+    n = 0
+    for r, q in zip(screed.open(ex_outfile2), screed.open(outfile2)):
+        n += 1
+        assert r.name == q.name
+        assert r.sequence == q.sequence
+        assert r.accuracy == q.accuracy
+    assert n > 0
+
+
 def test_sample_reads_randomly():
     infile = utils.get_temp_filename('test.fq')
     in_dir = os.path.dirname(infile)

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1553,7 +1553,7 @@ def test_split_paired_reads_3_output_dir():
     outfile2 = utils.get_temp_filename('paired.fq.2', output_dir)
 
     script = scriptpath('split-paired-reads.py')
-    args = [infile, '--output-dir', output_dir]
+    args = ['--output-dir', output_dir, infile]
 
     utils.runscript(script, args)
 


### PR DESCRIPTION
Follow up to https://twitter.com/beconstant/status/560885880907243520

The script now imports the whole `os` module since `os.makedirs()` is being used.

- [x] Is it mergable?
- [x] Did it pass the tests?
- [x] If it introduces new functionality in scripts/ is it tested?
  Check for code coverage.
- [x] Is it well formatted? Look at `make pep8`, `make diff_pylint_report`,
  `make cppcheck`, and `make doc` output. Use `make format` and manual
  fixing as needed.
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Is it documented in the ChangeLog?
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?