### PR TITLE
Add link to PR checklist in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,3 @@
 See [our development docs](https://khmer.readthedocs.org/en/latest/dev/).
+
+Be sure to include the [checklist](https://khmer.readthedocs.org/en/latest/dev/coding-guidelines-and-review.html#checklist) in the Pull-Request comment

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 See [our development docs](https://khmer.readthedocs.org/en/latest/dev/).
 
-Be sure to include the [checklist](https://khmer.readthedocs.org/en/latest/dev/coding-guidelines-and-review.html#checklist) in the Pull-Request comment
+Be sure to copy and paste the [checklist](https://khmer.readthedocs.org/en/latest/dev/coding-guidelines-and-review.html#checklist) in the Pull-Request comment


### PR DESCRIPTION
Since github adds the link to CONTRIBUTING.md when creating pull requests, I thought that the CONTRIBUTING.md should call out the checklist specifically.  An even cooler approach would be to modularize the text of the checklist block and include it in CONTRIBUTING.md and the docs, but my docs build foo isn't there yet. 

- [x] Is it mergable?
- [x] Did it pass the tests?
- [x] If it introduces new functionality in scripts/ is it tested?
  Check for code coverage.
- [x] Is it well formatted? Look at `make pep8`, `make diff_pylint_report`,
  `make cppcheck`, and `make doc` output. Use `make format` and manual
  fixing as needed.
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Is it documented in the ChangeLog?
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?