### PR TITLE
update split-paired-reads to support -1 and -2 options

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2015-02-09  Titus Brown  <titus@idyll.org>
+
+   * scripts/split-paired-reads.py: added -1 and -2 options to allow fine-
+   grain specification of output locations; switch to using write_record
+   instead of script-specific output functionality.
+   * tests/test_scripts.py: added accompanying tests.
+
 2015-02-09  Bede Constantinides  <bede.constantinides@manchester.ac.uk>
 
    * scripts/split-paired-reads.py: added -o option to allow specification

--- a/scripts/split-paired-reads.py
+++ b/scripts/split-paired-reads.py
@@ -22,6 +22,7 @@ import argparse
 import khmer
 from khmer.kfile import check_file_status, check_space
 from khmer.khmer_args import info
+from khmer.utils import write_record
 
 
 def get_parser():
@@ -34,6 +35,11 @@ def get_parser():
     specified using :option:`-o`/:option:`--output-dir`. This directory will be
     created if it does not already exist.
 
+    Alternatively, you can specify the filenames directly with
+    :option:`-1`/:option:`output_first` and
+    :option:`-2`/:option:`output_second`, which will override the :option:`-o`
+    setting on a file-specific basis.
+    
     Example::
 
         split-paired-reads.py tests/test-data/paired.fq
@@ -41,6 +47,10 @@ def get_parser():
     Example::
 
         split-paired-reads.py -o ~/reads-go-here tests/test-data/paired.fq
+
+        Example::
+
+        split-paired-reads.py -1 reads.1 -2 reads.2 tests/test-data/paired.fq
     """
     parser = argparse.ArgumentParser(
         description='Split interleaved reads into two files, left and right.',
@@ -48,10 +58,19 @@ def get_parser():
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
     parser.add_argument('infile')
+
     parser.add_argument('-o', '--output-dir', metavar="output_directory",
                         dest='output_directory', default='', help='Output '
                         'split reads to specified directory. Creates '
                         'directory if necessary')
+
+    parser.add_argument('-1', '--output-first', metavar='output_first',
+                        default=None, help='Output "left" reads to this '
+                        'file')
+    parser.add_argument('-2', '--output-second', metavar='output_second',
+                        default=None, help='Output "right" reads to this '
+                        'file')
+
     parser.add_argument('--version', action='version', version='%(prog)s '
                         + khmer.__version__)
     parser.add_argument('-f', '--force', default=False, action='store_true',
@@ -78,39 +97,28 @@ def main():
         out1 = os.path.basename(infile) + '.1'
         out2 = os.path.basename(infile) + '.2'
 
+    # OVERRIDE defaults with -1, -2
+    if args.output_first:
+        out1 = args.output_first
+    if args.output_second:
+        out2 = args.output_second
+
     fp_out1 = open(out1, 'w')
     fp_out2 = open(out2, 'w')
-
-    # is input file FASTQ or FASTA? Determine.
-    is_fastq = False
-    record = iter(screed.open(infile)).next()
-
-    if hasattr(record, 'accuracy'):
-        is_fastq = True
 
     counter1 = 0
     counter2 = 0
     index = None
     for index, record in enumerate(screed.open(infile)):
-        if index % 100000 == 0:
+        if index % 100000 == 0 and index:
             print >> sys.stderr, '...', index
 
         name = record.name
         if name.endswith('/1'):
-            if is_fastq:
-                print >> fp_out1, '@%s\n%s\n+\n%s' % (record.name,
-                                                      record.sequence,
-                                                      record.accuracy)
-            else:
-                print >> fp_out1, '>%s\n%s' % (record.name, record.sequence,)
+            write_record(record, fp_out1)
             counter1 += 1
         elif name.endswith('/2'):
-            if is_fastq:
-                print >> fp_out2, '@%s\n%s\n+\n%s' % (record.name,
-                                                      record.sequence,
-                                                      record.accuracy)
-            else:
-                print >> fp_out2, '>%s\n%s' % (record.name, record.sequence,)
+            write_record(record, fp_out2)
             counter2 += 1
 
     print >> sys.stderr, "DONE; split %d sequences (%d left, %d right)" % \

--- a/scripts/split-paired-reads.py
+++ b/scripts/split-paired-reads.py
@@ -36,9 +36,9 @@ def get_parser():
     created if it does not already exist.
 
     Alternatively, you can specify the filenames directly with
-    :option:`-1`/:option:`output_first` and
-    :option:`-2`/:option:`output_second`, which will override the :option:`-o`
-    setting on a file-specific basis.
+    :option:`-1`/:option:`--output-first` and
+    :option:`-2`/:option:`--output-second`, which will override the
+    :option:`-o`/:option:`--output-dir` setting on a file-specific basis.
 
     Example::
 

--- a/scripts/split-paired-reads.py
+++ b/scripts/split-paired-reads.py
@@ -39,7 +39,7 @@ def get_parser():
     :option:`-1`/:option:`output_first` and
     :option:`-2`/:option:`output_second`, which will override the :option:`-o`
     setting on a file-specific basis.
-    
+
     Example::
 
         split-paired-reads.py tests/test-data/paired.fq

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1577,6 +1577,117 @@ def test_split_paired_reads_3_output_dir():
     assert n > 0
 
 
+def test_split_paired_reads_3_output_files():
+    # test input file
+    infile = utils.get_test_data('paired.fq')
+
+    ex_outfile1 = utils.get_test_data('paired.fq.1')
+    ex_outfile2 = utils.get_test_data('paired.fq.2')
+
+    # actual output files...
+    outfile1 = utils.get_temp_filename('xxx')
+    output_dir = os.path.dirname(outfile1)
+    outfile2 = utils.get_temp_filename('yyy', output_dir)
+
+    script = scriptpath('split-paired-reads.py')
+    args = ['-1', outfile1, '-2', outfile2, infile]
+
+    utils.runscript(script, args)
+
+    assert os.path.exists(outfile1), outfile1
+    assert os.path.exists(outfile2), outfile2
+
+    n = 0
+    for r, q in zip(screed.open(ex_outfile1), screed.open(outfile1)):
+        n += 1
+        assert r.name == q.name
+        assert r.sequence == q.sequence
+        assert r.accuracy == q.accuracy
+    assert n > 0
+
+    n = 0
+    for r, q in zip(screed.open(ex_outfile2), screed.open(outfile2)):
+        n += 1
+        assert r.name == q.name
+        assert r.sequence == q.sequence
+        assert r.accuracy == q.accuracy
+    assert n > 0
+
+
+def test_split_paired_reads_3_output_files_left():
+    # test input file
+    infile = utils.get_test_data('paired.fq')
+
+    ex_outfile1 = utils.get_test_data('paired.fq.1')
+    ex_outfile2 = utils.get_test_data('paired.fq.2')
+
+    # actual output files...
+    outfile1 = utils.get_temp_filename('xxx')
+    output_dir = os.path.dirname(outfile1)
+    outfile2 = utils.get_temp_filename('paired.fq.2', output_dir)
+
+    script = scriptpath('split-paired-reads.py')
+    args = ['-o', output_dir, '-1', outfile1, infile]
+
+    utils.runscript(script, args)
+
+    assert os.path.exists(outfile1), outfile1
+    assert os.path.exists(outfile2), outfile2
+
+    n = 0
+    for r, q in zip(screed.open(ex_outfile1), screed.open(outfile1)):
+        n += 1
+        assert r.name == q.name
+        assert r.sequence == q.sequence
+        assert r.accuracy == q.accuracy
+    assert n > 0
+
+    n = 0
+    for r, q in zip(screed.open(ex_outfile2), screed.open(outfile2)):
+        n += 1
+        assert r.name == q.name
+        assert r.sequence == q.sequence
+        assert r.accuracy == q.accuracy
+    assert n > 0
+
+
+def test_split_paired_reads_3_output_files_right():
+    # test input file
+    infile = utils.get_test_data('paired.fq')
+
+    ex_outfile1 = utils.get_test_data('paired.fq.1')
+    ex_outfile2 = utils.get_test_data('paired.fq.2')
+
+    # actual output files...
+    outfile1 = utils.get_temp_filename('paired.fq.1')
+    output_dir = os.path.dirname(outfile1)
+    outfile2 = utils.get_temp_filename('yyy', output_dir)
+
+    script = scriptpath('split-paired-reads.py')
+    args = ['-2', outfile2, '-o', output_dir, infile]
+
+    utils.runscript(script, args)
+
+    assert os.path.exists(outfile1), outfile1
+    assert os.path.exists(outfile2), outfile2
+
+    n = 0
+    for r, q in zip(screed.open(ex_outfile1), screed.open(outfile1)):
+        n += 1
+        assert r.name == q.name
+        assert r.sequence == q.sequence
+        assert r.accuracy == q.accuracy
+    assert n > 0
+
+    n = 0
+    for r, q in zip(screed.open(ex_outfile2), screed.open(outfile2)):
+        n += 1
+        assert r.name == q.name
+        assert r.sequence == q.sequence
+        assert r.accuracy == q.accuracy
+    assert n > 0
+
+
 def test_sample_reads_randomly():
     infile = utils.get_temp_filename('test.fq')
     in_dir = os.path.dirname(infile)


### PR DESCRIPTION
Fixes #761, addresses most of https://github.com/ged-lab/khmer/issues/732#issuecomment-71903726 (although streaming won't work until the next release of screed).

- [x] Is it mergable?
- [x] Did it pass the tests?
- [x] If it introduces new functionality in scripts/ is it tested?
  Check for code coverage.
- [x] Is it well formatted? Look at `make pep8`, `make diff_pylint_report`,
  `make cppcheck`, and `make doc` output. Use `make format` and manual
  fixing as needed.
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Is it documented in the ChangeLog?
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?