### PR TITLE
fix a glitch about string formatting in sample-reads-randomly.py

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2015-02-13  Qingpeng Zhang  <qingpeng@msu.edu>
+
+   * scripts/sample-reads-randomly.py: fix a glitch about string formatting.
+
 2015-02-11  Titus Brown  <titus@idyll.org>
 
    * khmer/_khmermodule.cc: fixed k-mer size checking; updated some error

--- a/scripts/sample-reads-randomly.py
+++ b/scripts/sample-reads-randomly.py
@@ -140,9 +140,8 @@ def main():
             if total % 10000 == 0:
                 print >>sys.stderr, '...', total, 'reads scanned'
                 if total >= args.max_reads:
-                    print >>sys.stderr, 'reached upper limit of %d reads',\
-                        ' (see -M); exiting' \
-                        % args.max_reads
+                    print >>sys.stderr, 'reached upper limit of %d reads' % \
+                        args.max_reads, '(see -M); exiting'
                     break
 
             # collect first N reads

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1689,14 +1689,14 @@ def test_split_paired_reads_3_output_files_right():
 
 
 def test_sample_reads_randomly():
-    infile = utils.get_temp_filename('test.fq')
+    infile = utils.get_temp_filename('test.fa')
     in_dir = os.path.dirname(infile)
 
-    shutil.copyfile(utils.get_test_data('test-fastq-reads.fq'), infile)
+    shutil.copyfile(utils.get_test_data('test-reads.fa'), infile)
 
     script = scriptpath('sample-reads-randomly.py')
     # fix random number seed for reproducibility
-    args = ['-N', '10', '-R', '1']
+    args = ['-N', '10', '-M', '12000', '-R', '1']
     args.append(infile)
     utils.runscript(script, args, in_dir)
 
@@ -1704,11 +1704,11 @@ def test_sample_reads_randomly():
     assert os.path.exists(outfile), outfile
 
     seqs = set([r.name for r in screed.open(outfile)])
-    assert seqs == set(['895:1:1:1326:7273', '895:1:1:1373:4848',
-                        '895:1:1:1264:15854', '895:1:1:1338:15407',
-                        '895:1:1:1327:15301', '895:1:1:1265:2265',
-                        '895:1:1:1327:13028', '895:1:1:1368:4434',
-                        '895:1:1:1335:19932', '895:1:1:1340:19387'])
+    assert seqs == set(['850:2:1:2691:14602/1', '850:2:1:1762:5439/1',
+                        '850:2:1:2399:20086/2', '850:2:1:2503:4494/2',
+                        '850:2:1:2084:17145/1', '850:2:1:2273:13309/1',
+                        '850:2:1:2263:11143/2', '850:2:1:1984:7162/2',
+                        '850:2:1:2065:16816/1', '850:2:1:1792:15774/2'])
 
 
 def test_fastq_to_fasta():


### PR DESCRIPTION
I met this error when the condition of that block of codes is satisfied, as below. I think this is a simple problem and the fix should work.
 

[qingpeng@dev-intel14 Subset]$ sample-reads-randomly.py -N 100 -M 12000 -R 1 -o test20000.fa.100 test20000.fa

|| This is the script 'sample-reads-randomly.py' in khmer.
|| You are running khmer version 1.3
|| You are also using screed version 0.7
||
|| If you use this script in a publication, please cite EACH of the following:
||
||   * MR Crusoe et al., 2014. http://dx.doi.org/10.6084/m9.figshare.979190
||
|| Please see http://khmer.readthedocs.org/en/latest/citations.html for details.

Subsampling 100 reads using reservoir sampling.
Subsampled reads will be placed in test20000.fa.100

opening test20000.fa for reading
... 10000 reads scanned
... 20000 reads scanned
reached upper limit of %d readsTraceback (most recent call last):
  File "/opt/software/khmer/1.3--GCC-4.4.5/bin/sample-reads-randomly.py", line 5, in <module>
    pkg_resources.run_script('khmer==1.3', 'sample-reads-randomly.py')
  File "build/bdist.linux-x86_64/egg/pkg_resources.py", line 528, in run_script
    """List of resource names in the directory (like ``os.listdir()``)"""
  File "build/bdist.linux-x86_64/egg/pkg_resources.py", line 1394, in run_script
    if cop == 'not':
  File "/opt/software/khmer/1.3--GCC-4.4.5/lib/python2.7/site-packages/khmer-1.3-py2.7-linux-x86_64.egg/EGG-INFO/scripts/sample-reads-randomly.py", line 179, in <module>
    main()
  File "/opt/software/khmer/1.3--GCC-4.4.5/lib/python2.7/site-packages/khmer-1.3-py2.7-linux-x86_64.egg/EGG-INFO/scripts/sample-reads-randomly.py", line 144, in main
    % args.max_reads
TypeError: not all arguments converted during string formatting