### PR TITLE
Some _khmermodule.cc refactoring

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2015-02-24  Luiz Irber  <irberlui@msu.edu>
+
+   * khmer/_khmermodule.cc: Update extension to use recommended practices,
+   PyLong instead of PyInt, Type initialization, PyBytes instead of PyString.
+   Replace common initialization with explicit type structs, and all types
+   conform to the CPython checklist.
+
 2015-02-24  Michael R. Crusoe  <mcrusoe@msu.edu>
 
    * jenkins-build.sh: remove examples/stamps/do.sh testing for now; takes too

--- a/khmer/__init__.py
+++ b/khmer/__init__.py
@@ -9,10 +9,9 @@ This is khmer; please see http://khmer.readthedocs.org/.
 """
 
 from khmer._khmer import CountingHash
-from khmer._khmer import _new_hashbits
-from khmer._khmer import _LabelHash
-from khmer._khmer import _Hashbits
-from khmer._khmer import _HLLCounter
+from khmer._khmer import LabelHash as _LabelHash
+from khmer._khmer import Hashbits as _Hashbits
+from khmer._khmer import HLLCounter as _HLLCounter
 from khmer._khmer import ReadAligner
 
 from khmer._khmer import forward_hash  # figuregen/*.py

--- a/khmer/__init__.py
+++ b/khmer/__init__.py
@@ -58,7 +58,7 @@ def new_hashbits(k, starting_size, n_tables=2):
     """
     primes = get_n_primes_above_x(n_tables, starting_size)
 
-    return _new_hashbits(k, primes)
+    return _Hashbits(k, primes)
 
 
 def new_counting_hash(k, starting_size, n_tables=2):
@@ -81,7 +81,7 @@ def load_hashbits(filename):
     Keyword argument:
     filename -- the name of the hashbits file
     """
-    hashtable = _new_hashbits(1, [1])
+    hashtable = _Hashbits(1, [1])
     hashtable.load(filename)
 
     return hashtable

--- a/khmer/__init__.py
+++ b/khmer/__init__.py
@@ -8,7 +8,7 @@
 This is khmer; please see http://khmer.readthedocs.org/.
 """
 
-from khmer._khmer import _new_counting_hash
+from khmer._khmer import CountingHash
 from khmer._khmer import _new_hashbits
 from khmer._khmer import _LabelHash
 from khmer._khmer import _Hashbits
@@ -72,7 +72,7 @@ def new_counting_hash(k, starting_size, n_tables=2):
     """
     primes = get_n_primes_above_x(n_tables, starting_size)
 
-    return _new_counting_hash(k, primes)
+    return CountingHash(k, primes)
 
 
 def load_hashbits(filename):
@@ -93,7 +93,7 @@ def load_counting_hash(filename):
     Keyword argument:
     filename -- the name of the counting_hash file
     """
-    hashtable = _new_counting_hash(1, [1])
+    hashtable = CountingHash(1, [1])
     hashtable.load(filename)
 
     return hashtable

--- a/khmer/_khmermodule.cc
+++ b/khmer/_khmermodule.cc
@@ -3709,29 +3709,25 @@ typedef struct {
     //PyObject_HEAD
     khmer_KHashbits_Object khashbits;
     LabelHash * labelhash;
-} khmer_KLabelHashObject;
+} khmer_KLabelHash_Object;
 
-static void khmer_labelhash_dealloc(PyObject *);
-static int khmer_labelhash_init(khmer_KLabelHashObject * self, PyObject *args,
+static int khmer_labelhash_init(khmer_KLabelHash_Object * self, PyObject *args,
                                 PyObject *kwds);
 static PyObject * khmer_labelhash_new(PyTypeObject * type, PyObject *args,
                                       PyObject *kwds);
 
-#define is_labelhash_obj(v)  (Py_TYPE(v) == &khmer_KLabelHashType)
+#define is_labelhash_obj(v)  (Py_TYPE(v) == &khmer_KLabelHash_Type)
 
 //
 // khmer_labelhash_dealloc -- clean up a labelhash object.
 //
 
-static void khmer_labelhash_dealloc(PyObject* obj)
+static void khmer_labelhash_dealloc(khmer_KLabelHash_Object * obj)
 {
-    khmer_KLabelHashObject * self = (khmer_KLabelHashObject *) obj;
-
-    delete self->labelhash;
-    self->labelhash = NULL;
+    delete obj->labelhash;
+    obj->labelhash = NULL;
 
     Py_TYPE(obj)->tp_free((PyObject*)obj);
-    //PyObject_Del((PyObject *) obj);
 }
 
 // a little weird; we don't actually want to call Hashbits' new method. Rather, we
@@ -3740,8 +3736,8 @@ static void khmer_labelhash_dealloc(PyObject* obj)
 static PyObject * khmer_labelhash_new(PyTypeObject *type, PyObject *args,
                                       PyObject *kwds)
 {
-    khmer_KLabelHashObject *self;
-    self = (khmer_KLabelHashObject*)type->tp_alloc(type, 0);
+    khmer_KLabelHash_Object *self;
+    self = (khmer_KLabelHash_Object*)type->tp_alloc(type, 0);
 
     if (self != NULL) {
         WordLength k = 0;
@@ -3785,7 +3781,7 @@ static PyObject * khmer_labelhash_new(PyTypeObject *type, PyObject *args,
     return (PyObject *) self;
 }
 
-static int khmer_labelhash_init(khmer_KLabelHashObject * self, PyObject *args,
+static int khmer_labelhash_init(khmer_KLabelHash_Object * self, PyObject *args,
                                 PyObject *kwds)
 {
     if (khmer_KHashbits_Type.tp_init((PyObject *)self, args, kwds) < 0) {
@@ -3797,9 +3793,10 @@ static int khmer_labelhash_init(khmer_KLabelHashObject * self, PyObject *args,
     return 0;
 }
 
-static PyObject * labelhash_get_label_dict(PyObject * self, PyObject * args)
+static
+PyObject *
+labelhash_get_label_dict(khmer_KLabelHash_Object * me, PyObject * args)
 {
-    khmer_KLabelHashObject * me = (khmer_KLabelHashObject *) self;
     LabelHash * hb = me->labelhash;
 
     PyObject * d = PyDict_New();
@@ -3821,10 +3818,11 @@ static PyObject * labelhash_get_label_dict(PyObject * self, PyObject * args)
     return d;
 }
 
-static PyObject * labelhash_consume_fasta_and_tag_with_labels(
-    PyObject * self, PyObject * args)
+static
+PyObject *
+labelhash_consume_fasta_and_tag_with_labels(khmer_KLabelHash_Object * me,
+        PyObject * args)
 {
-    khmer_KLabelHashObject * me = (khmer_KLabelHashObject *) self;
     LabelHash * hb = me->labelhash;
 
     std::ofstream outfile;
@@ -3857,10 +3855,11 @@ static PyObject * labelhash_consume_fasta_and_tag_with_labels(
 
 }
 
-static PyObject * labelhash_consume_partitioned_fasta_and_tag_with_labels(
-    PyObject * self, PyObject * args)
+static
+PyObject *
+labelhash_consume_partitioned_fasta_and_tag_with_labels(
+    khmer_KLabelHash_Object * me, PyObject * args)
 {
-    khmer_KLabelHashObject * me = (khmer_KLabelHashObject *) self;
     LabelHash * labelhash = me->labelhash;
 
     const char * filename;
@@ -3888,10 +3887,11 @@ static PyObject * labelhash_consume_partitioned_fasta_and_tag_with_labels(
     return Py_BuildValue("IK", total_reads, n_consumed);
 }
 
-static PyObject * labelhash_consume_sequence_and_tag_with_labels(
-    PyObject * self, PyObject * args)
+static
+PyObject *
+labelhash_consume_sequence_and_tag_with_labels(khmer_KLabelHash_Object * me,
+        PyObject * args)
 {
-    khmer_KLabelHashObject * me = (khmer_KLabelHashObject *) self;
     LabelHash * hb = me->labelhash;
     const char * seq = NULL;
     unsigned long long c = 0;
@@ -3909,10 +3909,11 @@ static PyObject * labelhash_consume_sequence_and_tag_with_labels(
     return Py_BuildValue("K", n_consumed);
 }
 
-static PyObject * labelhash_sweep_label_neighborhood(PyObject * self,
-        PyObject * args)
+static
+PyObject *
+labelhash_sweep_label_neighborhood(khmer_KLabelHash_Object * me,
+                                   PyObject * args)
 {
-    khmer_KLabelHashObject * me = (khmer_KLabelHashObject *) self;
     LabelHash * hb = me->labelhash;
 
     const char * seq = NULL;
@@ -3980,10 +3981,11 @@ static PyObject * labelhash_sweep_label_neighborhood(PyObject * self,
 // Similar to find_all_tags, but returns tags in a way actually usable by python
 // need a tags_in_sequence iterator or function in c++ land for reuse in all
 // these functions
-static PyObject * labelhash_sweep_tag_neighborhood(PyObject * self,
-        PyObject *args)
+
+static
+PyObject *
+labelhash_sweep_tag_neighborhood(khmer_KLabelHash_Object * me, PyObject * args)
 {
-    khmer_KLabelHashObject * me = (khmer_KLabelHashObject *) self;
     LabelHash * labelhash = me->labelhash;
 
     const char * seq = NULL;
@@ -4042,11 +4044,10 @@ static PyObject * labelhash_sweep_tag_neighborhood(PyObject * self,
     return x;
 }
 
-
-static PyObject * labelhash_get_tag_labels(PyObject * self, PyObject * args)
+static
+PyObject *
+labelhash_get_tag_labels(khmer_KLabelHash_Object * me, PyObject * args)
 {
-
-    khmer_KLabelHashObject * me = (khmer_KLabelHashObject *) self;
     LabelHash * labelhash = me->labelhash;
 
     HashIntoType tag;
@@ -4071,9 +4072,10 @@ static PyObject * labelhash_get_tag_labels(PyObject * self, PyObject * args)
     return x;
 }
 
-static PyObject * labelhash_n_labels(PyObject * self, PyObject * args)
+static
+PyObject *
+labelhash_n_labels(khmer_KLabelHash_Object * me, PyObject * args)
 {
-    khmer_KLabelHashObject * me = (khmer_KLabelHashObject *) self;
     LabelHash * labelhash = me->labelhash;
 
     if (!PyArg_ParseTuple(args, "")) {
@@ -4084,26 +4086,25 @@ static PyObject * labelhash_n_labels(PyObject * self, PyObject * args)
 }
 
 static PyMethodDef khmer_labelhash_methods[] = {
-    { "consume_fasta_and_tag_with_labels", labelhash_consume_fasta_and_tag_with_labels, METH_VARARGS, "" },
-    { "sweep_label_neighborhood", labelhash_sweep_label_neighborhood, METH_VARARGS, "" },
-    {"consume_partitioned_fasta_and_tag_with_labels", labelhash_consume_partitioned_fasta_and_tag_with_labels, METH_VARARGS, "" },
-    {"sweep_tag_neighborhood", labelhash_sweep_tag_neighborhood, METH_VARARGS, "" },
-    {"get_tag_labels", labelhash_get_tag_labels, METH_VARARGS, ""},
-    {"consume_sequence_and_tag_with_labels", labelhash_consume_sequence_and_tag_with_labels, METH_VARARGS, "" },
-    {"n_labels", labelhash_n_labels, METH_VARARGS, ""},
-    {"get_label_dict", labelhash_get_label_dict, METH_VARARGS, "" },
-
+    { "consume_fasta_and_tag_with_labels", (PyCFunction)labelhash_consume_fasta_and_tag_with_labels, METH_VARARGS, "" },
+    { "sweep_label_neighborhood", (PyCFunction)labelhash_sweep_label_neighborhood, METH_VARARGS, "" },
+    {"consume_partitioned_fasta_and_tag_with_labels", (PyCFunction)labelhash_consume_partitioned_fasta_and_tag_with_labels, METH_VARARGS, "" },
+    {"sweep_tag_neighborhood", (PyCFunction)labelhash_sweep_tag_neighborhood, METH_VARARGS, "" },
+    {"get_tag_labels", (PyCFunction)labelhash_get_tag_labels, METH_VARARGS, ""},
+    {"consume_sequence_and_tag_with_labels", (PyCFunction)labelhash_consume_sequence_and_tag_with_labels, METH_VARARGS, "" },
+    {"n_labels", (PyCFunction)labelhash_n_labels, METH_VARARGS, ""},
+    {"get_label_dict", (PyCFunction)labelhash_get_label_dict, METH_VARARGS, "" },
     {NULL, NULL, 0, NULL}           /* sentinel */
 };
 
-static PyTypeObject khmer_KLabelHashType = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    "_LabelHash",            /* tp_name */
-    sizeof(khmer_KLabelHashObject), /* tp_basicsize */
+static PyTypeObject khmer_KLabelHash_Type = {
+    PyVarObject_HEAD_INIT(NULL, 0)  /* init & ob_size */
+    "_khmer._LabelHash",            /* tp_name */
+    sizeof(khmer_KLabelHash_Object), /* tp_basicsize */
     0,                       /* tp_itemsize */
     (destructor)khmer_labelhash_dealloc, /* tp_dealloc */
     0,                       /* tp_print */
-    0,  /* khmer_labelhash_getattr, tp_getattr */
+    0,                       /* tp_getattr */
     0,                       /* tp_setattr */
     0,                       /* tp_compare */
     0,                       /* tp_repr */
@@ -4134,6 +4135,7 @@ static PyTypeObject khmer_KLabelHashType = {
     0,                       /* tp_dictoffset */
     (initproc)khmer_labelhash_init,   /* tp_init */
     0,                       /* tp_alloc */
+    khmer_labelhash_new,      /* tp_new */
 };
 
 static PyObject * readaligner_align(khmer_ReadAligner_Object * me,
@@ -4688,17 +4690,14 @@ init_khmer(void)
         return;
     }
 
-    // implemented __new__ for Hashbits; keeping factory func around as well
-    // for backwards compat with old scripts
     khmer_KHashbits_Type.tp_methods = khmer_hashbits_methods;
     if (PyType_Ready(&khmer_KHashbits_Type) < 0) {
         return;
     }
     // add LabelHash
 
-    khmer_KLabelHashType.tp_base = &khmer_KHashbits_Type;
-    khmer_KLabelHashType.tp_new = khmer_labelhash_new;
-    if (PyType_Ready(&khmer_KLabelHashType) < 0) {
+    khmer_KLabelHash_Type.tp_base = &khmer_KHashbits_Type;
+    if (PyType_Ready(&khmer_KLabelHash_Type) < 0) {
         return;
     }
 
@@ -4750,8 +4749,11 @@ init_khmer(void)
         return;
     }
 
-    Py_INCREF(&khmer_KLabelHashType);
-    PyModule_AddObject(m, "_LabelHash", (PyObject *)&khmer_KLabelHashType);
+    Py_INCREF(&khmer_KLabelHash_Type);
+    if (PyModule_AddObject(m, "_LabelHash",
+                           (PyObject *)&khmer_KLabelHash_Type) < 0) {
+        return;
+    }
 
     Py_INCREF(&khmer_KHLLCounter_Type);
     PyModule_AddObject(m, "_HLLCounter", (PyObject *)&khmer_KHLLCounter_Type);

--- a/khmer/_khmermodule.cc
+++ b/khmer/_khmermodule.cc
@@ -99,8 +99,6 @@ _common_init_Type(
         throw khmer_exception();
     }
 
-    tobj.ob_size        = 0;
-    tobj.ob_type        = &PyType_Type;
     tobj.tp_name        = name;
     tobj.tp_basicsize       = sizeof( OBJECT );
     tobj.tp_alloc       = PyType_GenericAlloc;
@@ -168,7 +166,7 @@ namespace python
 {
 
 
-static PyTypeObject Read_Type = { PyObject_HEAD_INIT( NULL ) };
+static PyTypeObject Read_Type = { PyVarObject_HEAD_INIT(NULL, 0) };
 
 
 typedef struct {
@@ -285,8 +283,8 @@ _init_Read_Type( )
 
 static PyTypeObject ReadParser_Type
 CPYCHECKER_TYPE_OBJECT_FOR_TYPEDEF("ReadParser_Object")
-    = { PyObject_HEAD_INIT( NULL ) };
-static PyTypeObject ReadPairIterator_Type = { PyObject_HEAD_INIT( NULL ) };
+    = { PyVarObject_HEAD_INIT(NULL, 0) };
+static PyTypeObject ReadPairIterator_Type = { PyVarObject_HEAD_INIT(NULL, 0) };
 
 
 typedef struct {
@@ -678,8 +676,7 @@ static void khmer_subset_dealloc(PyObject *);
 static PyObject * khmer_subset_getattr(PyObject * obj, char * name);
 
 static PyTypeObject khmer_KSubsetPartitionType = {
-    PyObject_HEAD_INIT(NULL)
-    0,
+    PyVarObject_HEAD_INIT(NULL, 0)
     "KSubset", sizeof(khmer_KSubsetPartitionObject),
     0,
     khmer_subset_dealloc,   /*tp_dealloc*/
@@ -1561,13 +1558,12 @@ khmer_counting_getattr(PyObject * obj, char * name)
     return Py_FindMethod(khmer_counting_methods, obj, name);
 }
 
-#define is_counting_obj(v)  ((v)->ob_type == &khmer_KCountingHashType)
+#define is_counting_obj(v)  (Py_TYPE(v) == &khmer_KCountingHashType)
 
 static PyTypeObject khmer_KCountingHashType
 CPYCHECKER_TYPE_OBJECT_FOR_TYPEDEF("khmer_KCountingHashObject")
 = {
-    PyObject_HEAD_INIT(NULL)
-    0,
+    PyVarObject_HEAD_INIT(NULL, 0)
     "KCountingHash", sizeof(khmer_KCountingHashObject),
     0,
     khmer_counting_dealloc, /*tp_dealloc*/
@@ -1682,8 +1678,7 @@ static PyObject * khmer_hashbits_getattr(PyObject * obj, char * name);
 static PyTypeObject khmer_KHashbitsType
 CPYCHECKER_TYPE_OBJECT_FOR_TYPEDEF("khmer_KHashbitsObject")
 = {
-    PyObject_HEAD_INIT(NULL)
-    0,
+    PyVarObject_HEAD_INIT(NULL, 0)
     "Hashbits", sizeof(khmer_KHashbitsObject),
     0,
     (destructor)khmer_hashbits_dealloc, /*tp_dealloc*/
@@ -3412,7 +3407,7 @@ static int khmer_hashbits_init(khmer_KHashbitsObject * self, PyObject * args,
     return 0;
 }
 
-#define is_hashbits_obj(v)  ((v)->ob_type == &khmer_KHashbitsType)
+#define is_hashbits_obj(v)  (Py_TYPE(v) == &khmer_KHashbitsType)
 
 ////////////////////////////////////////////////////////////////////////////
 
@@ -3624,7 +3619,7 @@ static int khmer_labelhash_init(khmer_KLabelHashObject * self, PyObject *args,
 static PyObject * khmer_labelhash_new(PyTypeObject * type, PyObject *args,
                                       PyObject *kwds);
 
-#define is_labelhash_obj(v)  ((v)->ob_type == &khmer_KLabelHashType)
+#define is_labelhash_obj(v)  (Py_TYPE(v) == &khmer_KLabelHashType)
 
 //
 // khmer_labelhash_dealloc -- clean up a labelhash object.
@@ -3637,7 +3632,7 @@ static void khmer_labelhash_dealloc(PyObject* obj)
     delete self->labelhash;
     self->labelhash = NULL;
 
-    obj->ob_type->tp_free((PyObject*)self);
+    Py_TYPE(obj)->tp_free((PyObject*)obj);
     //PyObject_Del((PyObject *) obj);
 }
 
@@ -4004,8 +3999,7 @@ static PyMethodDef khmer_labelhash_methods[] = {
 };
 
 static PyTypeObject khmer_KLabelHashType = {
-    PyObject_HEAD_INIT(NULL)
-    0,                       /* ob_size */
+    PyVarObject_HEAD_INIT(NULL, 0)
     "_LabelHash",            /* tp_name */
     sizeof(khmer_KLabelHashObject), /* tp_basicsize */
     0,                       /* tp_itemsize */
@@ -4264,7 +4258,7 @@ static void khmer_hashbits_dealloc(PyObject* obj)
     delete self->hashbits;
     self->hashbits = NULL;
 
-    self->ob_type->tp_free((PyObject*)obj);
+    Py_TYPE(obj)->tp_free((PyObject*)obj);
     //PyObject_Del((PyObject *) obj);
 }
 
@@ -4337,7 +4331,7 @@ static void khmer_hllcounter_dealloc(khmer_KHLLCounter_Object * obj)
     delete obj->hllcounter;
     obj->hllcounter = NULL;
 
-    obj->ob_type->tp_free((PyObject*)obj);
+    Py_TYPE(obj)->tp_free((PyObject*)obj);
 }
 
 static
@@ -4443,8 +4437,7 @@ static PyMethodDef khmer_hllcounter_methods[] = {
 };
 
 static PyTypeObject khmer_KHLLCounter_Type = {
-    PyObject_HEAD_INIT(NULL)
-    0,                                         /* ob_size */
+    PyVarObject_HEAD_INIT(NULL, 0)
     "khmer.KHLLCounter",                       /* tp_name */
     sizeof(khmer_KHLLCounter_Object),          /* tp_basicsize */
     0,                                         /* tp_itemsize */
@@ -4484,7 +4477,7 @@ static PyTypeObject khmer_KHLLCounter_Type = {
     khmer_hllcounter_new,                      /* tp_new */
 };
 
-#define is_hllcounter_obj(v)  ((v)->ob_type == &khmer_KHLLCounter_Type)
+#define is_hllcounter_obj(v)  (Py_TYPE(v) == &khmer_KHLLCounter_Type)
 
 
 //////////////////////////////

--- a/khmer/_khmermodule.cc
+++ b/khmer/_khmermodule.cc
@@ -27,6 +27,15 @@
 using namespace khmer;
 
 //
+// Python 2/3 compatibility: PyInt and PyLong
+//
+
+#if (PY_MAJOR_VERSION >= 3)
+#define PyInt_Check(arg) PyLong_Check(arg)
+#define PyInt_AsLong(arg) PyLong_AsLong(arg)
+#endif
+
+//
 // Function necessary for Python loading:
 //
 
@@ -550,7 +559,7 @@ _init_ReadParser_Type( )
     // Place pair mode constants into class dictionary.
     int result;
 
-    PyObject * value = PyInt_FromLong( IParser:: PAIR_MODE_ALLOW_UNPAIRED );
+    PyObject * value = PyLong_FromLong( IParser:: PAIR_MODE_ALLOW_UNPAIRED );
     result = PyDict_SetItemString(cls_attrs_DICT,
                                   "PAIR_MODE_ALLOW_UNPAIRED", value);
     Py_XDECREF(value);
@@ -559,7 +568,7 @@ _init_ReadParser_Type( )
         return;
     }
 
-    value = PyInt_FromLong( IParser:: PAIR_MODE_IGNORE_UNPAIRED );
+    value = PyLong_FromLong( IParser:: PAIR_MODE_IGNORE_UNPAIRED );
     result = PyDict_SetItemString(cls_attrs_DICT,
                                   "PAIR_MODE_IGNORE_UNPAIRED", value );
     Py_XDECREF(value);
@@ -568,7 +577,7 @@ _init_ReadParser_Type( )
         return;
     }
 
-    value = PyInt_FromLong( IParser:: PAIR_MODE_ERROR_ON_UNPAIRED );
+    value = PyLong_FromLong( IParser:: PAIR_MODE_ERROR_ON_UNPAIRED );
     result = PyDict_SetItemString(cls_attrs_DICT,
                                   "PAIR_MODE_ERROR_ON_UNPAIRED", value);
     Py_XDECREF(value);
@@ -786,7 +795,7 @@ static PyObject * hash_count(PyObject * self, PyObject * args)
 
     counting->count(kmer);
 
-    return PyInt_FromLong(1);
+    return PyLong_FromLong(1);
 }
 
 static PyObject * hash_output_fasta_kmer_pos_freq(PyObject * self,
@@ -804,7 +813,7 @@ static PyObject * hash_output_fasta_kmer_pos_freq(PyObject * self,
 
     counting->output_fasta_kmer_pos_freq(infile, outfile);
 
-    return PyInt_FromLong(0);
+    return PyLong_FromLong(0);
 }
 
 static PyObject * hash_consume_fasta(PyObject * self, PyObject * args)
@@ -891,7 +900,7 @@ static PyObject * hash_consume(PyObject * self, PyObject * args)
     unsigned int n_consumed;
     n_consumed = counting->consume_string(long_str);
 
-    return PyInt_FromLong(n_consumed);
+    return PyLong_FromLong(n_consumed);
 }
 
 static PyObject * hash_get_min_count(PyObject * self, PyObject * args)
@@ -914,7 +923,7 @@ static PyObject * hash_get_min_count(PyObject * self, PyObject * args)
     BoundedCounterType c = counting->get_min_count(long_str);
     unsigned int N = c;
 
-    return PyInt_FromLong(N);
+    return PyLong_FromLong(N);
 }
 
 static PyObject * hash_get_max_count(PyObject * self, PyObject * args)
@@ -937,7 +946,7 @@ static PyObject * hash_get_max_count(PyObject * self, PyObject * args)
     BoundedCounterType c = counting->get_max_count(long_str);
     unsigned int N = c;
 
-    return PyInt_FromLong(N);
+    return PyLong_FromLong(N);
 }
 
 static PyObject * hash_get_median_count(PyObject * self, PyObject * args)
@@ -1018,7 +1027,7 @@ static PyObject * hash_get(PyObject * self, PyObject * args)
         count = counting->get_count(s.c_str());
     }
 
-    return PyInt_FromLong(count);
+    return PyLong_FromLong(count);
 }
 
 static PyObject * count_trim_on_abundance(PyObject * self, PyObject * args)
@@ -1111,7 +1120,7 @@ static PyObject * count_find_spectral_error_positions(PyObject * self,
         return NULL;
     }
     for (Py_ssize_t i = 0; i < posns_size; i++) {
-        PyList_SET_ITEM(x, i, PyInt_FromLong(posns[i]));
+        PyList_SET_ITEM(x, i, PyLong_FromLong(posns[i]));
     }
 
     return x;
@@ -1236,7 +1245,7 @@ static PyObject * hash_get_ksize(PyObject * self, PyObject * args)
 
     unsigned int k = counting->ksize();
 
-    return PyInt_FromLong(k);
+    return PyLong_FromLong(k);
 }
 
 static PyObject * hash_get_hashsizes(PyObject * self, PyObject * args)
@@ -1621,10 +1630,10 @@ static PyObject* _new_counting_hash(PyObject * self, PyObject * args)
     }
     for (Py_ssize_t i = 0; i < sizes_list_o_length; i++) {
         PyObject * size_o = PyList_GET_ITEM(sizes_list_o, i);
-        if (PyInt_Check(size_o)) {
-            sizes.push_back((HashIntoType) PyInt_AsLong(size_o));
-        } else if (PyLong_Check(size_o)) {
+        if (PyLong_Check(size_o)) {
             sizes.push_back((HashIntoType) PyLong_AsUnsignedLongLong(size_o));
+        } else if (PyInt_Check(size_o)) {
+            sizes.push_back((HashIntoType) PyInt_AsLong(size_o));
         } else if (PyFloat_Check(size_o)) {
             sizes.push_back((HashIntoType) PyFloat_AS_DOUBLE(size_o));
         } else {
@@ -1873,7 +1882,7 @@ static PyObject * hashbits_n_tags(PyObject * self, PyObject * args)
         return NULL;
     }
 
-    return PyInt_FromSize_t(hashbits->n_tags());
+    return PyLong_FromSize_t(hashbits->n_tags());
 }
 
 static PyObject * hashbits_count(PyObject * self, PyObject * args)
@@ -1895,7 +1904,7 @@ static PyObject * hashbits_count(PyObject * self, PyObject * args)
 
     hashbits->count(kmer);
 
-    return PyInt_FromLong(1);
+    return PyLong_FromLong(1);
 }
 
 static PyObject * hashbits_consume(PyObject * self, PyObject * args)
@@ -1918,7 +1927,7 @@ static PyObject * hashbits_consume(PyObject * self, PyObject * args)
     unsigned int n_consumed;
     n_consumed = hashbits->consume_string(long_str);
 
-    return PyInt_FromLong(n_consumed);
+    return PyLong_FromLong(n_consumed);
 }
 
 static PyObject * hashbits_print_stop_tags(PyObject * self, PyObject * args)
@@ -2044,7 +2053,7 @@ static PyObject * hashbits_repartition_largest_partition(PyObject * self,
     unsigned long next_largest = subset_p->repartition_largest_partition(distance,
                                  threshold, frequency, *counting);
 
-    return PyInt_FromLong(next_largest);
+    return PyLong_FromLong(next_largest);
 }
 
 static PyObject * hashbits_get(PyObject * self, PyObject * args)
@@ -2078,7 +2087,7 @@ static PyObject * hashbits_get(PyObject * self, PyObject * args)
         return NULL;
     }
 
-    return PyInt_FromLong(count);
+    return PyLong_FromLong(count);
 }
 
 static PyObject * hashbits_calc_connected_graph_size(PyObject * self,
@@ -2121,7 +2130,7 @@ static PyObject * hashbits_kmer_degree(PyObject * self, PyObject * args)
         return NULL;
     }
 
-    return PyInt_FromLong(hashbits->kmer_degree(kmer_s));
+    return PyLong_FromLong(hashbits->kmer_degree(kmer_s));
 }
 
 static PyObject * hashbits_trim_on_stoptags(PyObject * self, PyObject * args)
@@ -2566,7 +2575,7 @@ static PyObject * hashbits_assign_partition_id(PyObject * self, PyObject *args)
     p = hashbits->partition->assign_partition_id(ppi->kmer,
             ppi->tagged_kmers);
 
-    return PyInt_FromLong(p);
+    return PyLong_FromLong(p);
 }
 
 static PyObject * hashbits_add_tag(PyObject * self, PyObject *args)
@@ -2681,7 +2690,7 @@ static PyObject * hashbits_output_partitions(PyObject * self, PyObject * args)
         return NULL;
     }
 
-    return PyInt_FromLong(n_partitions);
+    return PyLong_FromLong(n_partitions);
 }
 
 static PyObject * hashbits_find_unpart(PyObject * self, PyObject * args)
@@ -2710,7 +2719,7 @@ static PyObject * hashbits_find_unpart(PyObject * self, PyObject * args)
         return NULL;
     }
 
-    return PyInt_FromLong(n_singletons);
+    return PyLong_FromLong(n_singletons);
 
     // Py_INCREF(Py_None);
     // return Py_None;
@@ -3032,7 +3041,7 @@ static PyObject * hashbits__get_tag_density(PyObject * self, PyObject * args)
 
     unsigned int d = hashbits->_get_tag_density();
 
-    return PyInt_FromLong(d);
+    return PyLong_FromLong(d);
 }
 
 static PyObject * hashbits__validate_subset_partitionmap(PyObject * self,
@@ -3081,7 +3090,7 @@ static PyObject * hashbits_join_partitions(PyObject * self, PyObject * args)
 
     p1 = hashbits->partition->join_partitions(p1, p2);
 
-    return PyInt_FromLong(p1);
+    return PyLong_FromLong(p1);
 }
 
 static PyObject * hashbits_get_partition_id(PyObject * self, PyObject * args)
@@ -3098,7 +3107,7 @@ static PyObject * hashbits_get_partition_id(PyObject * self, PyObject * args)
     PartitionID partition_id;
     partition_id = hashbits->partition->get_partition_id(kmer);
 
-    return PyInt_FromLong(partition_id);
+    return PyLong_FromLong(partition_id);
 }
 
 static PyObject * hashbits_is_single_partition(PyObject * self,
@@ -3190,7 +3199,7 @@ static PyObject * hashbits_get_ksize(PyObject * self, PyObject * args)
 
     unsigned int k = hashbits->ksize();
 
-    return PyInt_FromLong(k);
+    return PyLong_FromLong(k);
 }
 
 
@@ -3364,10 +3373,10 @@ static PyObject* khmer_hashbits_new(PyTypeObject * type, PyObject * args,
         Py_ssize_t sizes_list_o_length = PyList_GET_SIZE(sizes_list_o);
         for (Py_ssize_t i = 0; i < sizes_list_o_length; i++) {
             PyObject * size_o = PyList_GET_ITEM(sizes_list_o, i);
-            if (PyInt_Check(size_o)) {
-                sizes.push_back((HashIntoType) PyInt_AsLong(size_o));
-            } else if (PyLong_Check(size_o)) {
+            if (PyLong_Check(size_o)) {
                 sizes.push_back((HashIntoType) PyLong_AsUnsignedLongLong(size_o));
+            } else if (PyInt_Check(size_o)) {
+                sizes.push_back((HashIntoType) PyInt_AsLong(size_o));
             } else if (PyFloat_Check(size_o)) {
                 sizes.push_back((HashIntoType) PyFloat_AS_DOUBLE(size_o));
             } else {
@@ -3645,10 +3654,10 @@ static PyObject * khmer_labelhash_new(PyTypeObject *type, PyObject *args,
         Py_ssize_t sizes_list_o_length = PyList_GET_SIZE(sizes_list_o);
         for (Py_ssize_t i = 0; i < sizes_list_o_length; i++) {
             PyObject * size_o = PyList_GET_ITEM(sizes_list_o, i);
-            if (PyInt_Check(size_o)) {
-                sizes.push_back((HashIntoType) PyInt_AsLong(size_o));
-            } else if (PyLong_Check(size_o)) {
+            if (PyLong_Check(size_o)) {
                 sizes.push_back((HashIntoType) PyLong_AsUnsignedLongLong(size_o));
+            } else if (PyInt_Check(size_o)) {
+                sizes.push_back((HashIntoType) PyInt_AsLong(size_o));
             } else if (PyFloat_Check(size_o)) {
                 sizes.push_back((HashIntoType) PyFloat_AS_DOUBLE(size_o));
             } else {
@@ -3969,7 +3978,7 @@ static PyObject * labelhash_n_labels(PyObject * self, PyObject * args)
         return NULL;
     }
 
-    return PyInt_FromSize_t(labelhash->n_labels());
+    return PyLong_FromSize_t(labelhash->n_labels());
 }
 
 static PyMethodDef khmer_labelhash_methods[] = {
@@ -4155,10 +4164,10 @@ static PyObject* _new_hashbits(PyObject * self, PyObject * args)
     Py_ssize_t sizes_list_o_length = PyList_GET_SIZE(sizes_list_o);
     for (Py_ssize_t i = 0; i < sizes_list_o_length; i++) {
         PyObject * size_o = PyList_GET_ITEM(sizes_list_o, i);
-        if (PyInt_Check(size_o)) {
-            sizes.push_back((HashIntoType) PyInt_AsLong(size_o));
-        } else if (PyLong_Check(size_o)) {
+        if (PyLong_Check(size_o)) {
             sizes.push_back((HashIntoType) PyLong_AsUnsignedLongLong(size_o));
+        } else if (PyInt_Check(size_o)) {
+            sizes.push_back((HashIntoType) PyInt_AsLong(size_o));
         } else if (PyFloat_Check(size_o)) {
             sizes.push_back((HashIntoType) PyFloat_AS_DOUBLE(size_o));
         } else {

--- a/khmer/_khmermodule.cc
+++ b/khmer/_khmermodule.cc
@@ -628,7 +628,7 @@ void free_subset_partition_info(void * p)
 typedef struct {
     PyObject_HEAD
     CountingHash * counting;
-} khmer_KCountingHashObject;
+} khmer_KCountingHash_Object;
 
 typedef struct {
     PyObject_HEAD
@@ -671,18 +671,21 @@ typedef struct {
     ReadAligner * aligner;
 } khmer_ReadAligner_Object;
 
-static void khmer_counting_dealloc(PyObject *);
+static void khmer_counting_dealloc(khmer_KCountingHash_Object * obj);
 
-static PyObject * hash_abundance_distribution(PyObject * self,
+static
+PyObject *
+hash_abundance_distribution(khmer_KCountingHash_Object * me, PyObject * args);
+
+static
+PyObject *
+hash_abundance_distribution_with_reads_parser(khmer_KCountingHash_Object * me,
         PyObject * args);
 
-static PyObject * hash_abundance_distribution_with_reads_parser(
-    PyObject * self,
-    PyObject * args);
-
-static PyObject * hash_set_use_bigcount(PyObject * self, PyObject * args)
+static
+PyObject *
+hash_set_use_bigcount(khmer_KCountingHash_Object * me, PyObject * args)
 {
-    khmer_KCountingHashObject * me = (khmer_KCountingHashObject *) self;
     CountingHash * counting = me->counting;
 
     PyObject * x;
@@ -698,9 +701,10 @@ static PyObject * hash_set_use_bigcount(PyObject * self, PyObject * args)
     Py_RETURN_NONE;
 }
 
-static PyObject * hash_get_use_bigcount(PyObject * self, PyObject * args)
+static
+PyObject *
+hash_get_use_bigcount(khmer_KCountingHash_Object * me, PyObject * args)
 {
-    khmer_KCountingHashObject * me = (khmer_KCountingHashObject *) self;
     CountingHash * counting = me->counting;
 
     if (!PyArg_ParseTuple(args, "")) {
@@ -712,9 +716,10 @@ static PyObject * hash_get_use_bigcount(PyObject * self, PyObject * args)
     return PyBool_FromLong((int)val);
 }
 
-static PyObject * hash_n_occupied(PyObject * self, PyObject * args)
+static
+PyObject *
+hash_n_occupied(khmer_KCountingHash_Object * me, PyObject * args)
 {
-    khmer_KCountingHashObject * me = (khmer_KCountingHashObject *) self;
     CountingHash * counting = me->counting;
 
     HashIntoType start = 0, stop = 0;
@@ -728,9 +733,10 @@ static PyObject * hash_n_occupied(PyObject * self, PyObject * args)
     return PyLong_FromUnsignedLongLong(n);
 }
 
-static PyObject * hash_n_unique_kmers(PyObject * self, PyObject * args)
+static
+PyObject *
+hash_n_unique_kmers(khmer_KCountingHash_Object * me, PyObject * args)
 {
-    khmer_KCountingHashObject * me = (khmer_KCountingHashObject *) self;
     CountingHash * counting = me->counting;
 
     HashIntoType n = counting->n_unique_kmers();
@@ -738,9 +744,10 @@ static PyObject * hash_n_unique_kmers(PyObject * self, PyObject * args)
     return PyLong_FromUnsignedLongLong(n);
 }
 
-static PyObject * hash_n_entries(PyObject * self, PyObject * args)
+static
+PyObject *
+hash_n_entries(khmer_KCountingHash_Object * me, PyObject * args)
 {
-    khmer_KCountingHashObject * me = (khmer_KCountingHashObject *) self;
     CountingHash * counting = me->counting;
 
     if (!PyArg_ParseTuple(args, "")) {
@@ -750,9 +757,10 @@ static PyObject * hash_n_entries(PyObject * self, PyObject * args)
     return PyLong_FromUnsignedLongLong(counting->n_entries());
 }
 
-static PyObject * hash_count(PyObject * self, PyObject * args)
+static
+PyObject *
+hash_count(khmer_KCountingHash_Object * me, PyObject * args)
 {
-    khmer_KCountingHashObject * me = (khmer_KCountingHashObject *) self;
     CountingHash * counting = me->counting;
 
     const char * kmer;
@@ -772,10 +780,11 @@ static PyObject * hash_count(PyObject * self, PyObject * args)
     return PyLong_FromLong(1);
 }
 
-static PyObject * hash_output_fasta_kmer_pos_freq(PyObject * self,
-        PyObject *args)
+static
+PyObject *
+hash_output_fasta_kmer_pos_freq(khmer_KCountingHash_Object * me,
+                                PyObject * args)
 {
-    khmer_KCountingHashObject * me = (khmer_KCountingHashObject *) self;
     CountingHash * counting = me->counting;
 
     const char * infile;
@@ -790,9 +799,10 @@ static PyObject * hash_output_fasta_kmer_pos_freq(PyObject * self,
     return PyLong_FromLong(0);
 }
 
-static PyObject * hash_consume_fasta(PyObject * self, PyObject * args)
+static
+PyObject *
+hash_consume_fasta(khmer_KCountingHash_Object * me, PyObject * args)
 {
-    khmer_KCountingHashObject * me  = (khmer_KCountingHashObject *) self;
     CountingHash * counting  = me->counting;
 
     const char * filename;
@@ -817,11 +827,11 @@ static PyObject * hash_consume_fasta(PyObject * self, PyObject * args)
     return Py_BuildValue("IK", total_reads, n_consumed);
 }
 
-static PyObject * hash_consume_fasta_with_reads_parser(
-    PyObject * self, PyObject * args
-)
+static
+PyObject *
+hash_consume_fasta_with_reads_parser(khmer_KCountingHash_Object * me,
+                                     PyObject * args)
 {
-    khmer_KCountingHashObject * me  = (khmer_KCountingHashObject *) self;
     CountingHash * counting  = me->counting;
 
     PyObject * rparser_obj = NULL;
@@ -854,9 +864,10 @@ static PyObject * hash_consume_fasta_with_reads_parser(
     return Py_BuildValue("IK", total_reads, n_consumed);
 }
 
-static PyObject * hash_consume(PyObject * self, PyObject * args)
+static
+PyObject *
+hash_consume(khmer_KCountingHash_Object * me, PyObject * args)
 {
-    khmer_KCountingHashObject * me = (khmer_KCountingHashObject *) self;
     CountingHash * counting = me->counting;
 
     const char * long_str;
@@ -877,9 +888,10 @@ static PyObject * hash_consume(PyObject * self, PyObject * args)
     return PyLong_FromLong(n_consumed);
 }
 
-static PyObject * hash_get_min_count(PyObject * self, PyObject * args)
+static
+PyObject *
+hash_get_min_count(khmer_KCountingHash_Object * me, PyObject * args)
 {
-    khmer_KCountingHashObject * me = (khmer_KCountingHashObject *) self;
     CountingHash * counting = me->counting;
 
     const char * long_str;
@@ -900,9 +912,10 @@ static PyObject * hash_get_min_count(PyObject * self, PyObject * args)
     return PyLong_FromLong(N);
 }
 
-static PyObject * hash_get_max_count(PyObject * self, PyObject * args)
+static
+PyObject *
+hash_get_max_count(khmer_KCountingHash_Object * me, PyObject * args)
 {
-    khmer_KCountingHashObject * me = (khmer_KCountingHashObject *) self;
     CountingHash * counting = me->counting;
 
     const char * long_str;
@@ -923,9 +936,10 @@ static PyObject * hash_get_max_count(PyObject * self, PyObject * args)
     return PyLong_FromLong(N);
 }
 
-static PyObject * hash_get_median_count(PyObject * self, PyObject * args)
+static
+PyObject *
+hash_get_median_count(khmer_KCountingHash_Object * me, PyObject * args)
 {
-    khmer_KCountingHashObject * me = (khmer_KCountingHashObject *) self;
     CountingHash * counting = me->counting;
 
     const char * long_str;
@@ -948,9 +962,10 @@ static PyObject * hash_get_median_count(PyObject * self, PyObject * args)
     return Py_BuildValue("iff", med, average, stddev);
 }
 
-static PyObject * hash_get_kadian_count(PyObject * self, PyObject * args)
+static
+PyObject *
+hash_get_kadian_count(khmer_KCountingHash_Object * me, PyObject * args)
 {
-    khmer_KCountingHashObject * me = (khmer_KCountingHashObject *) self;
     CountingHash * counting = me->counting;
 
     const char * long_str;
@@ -973,9 +988,10 @@ static PyObject * hash_get_kadian_count(PyObject * self, PyObject * args)
     return Py_BuildValue("i", kad);
 }
 
-static PyObject * hash_get(PyObject * self, PyObject * args)
+static
+PyObject *
+hash_get(khmer_KCountingHash_Object * me, PyObject * args)
 {
-    khmer_KCountingHashObject * me = (khmer_KCountingHashObject *) self;
     CountingHash * counting = me->counting;
 
     PyObject * arg;
@@ -1004,9 +1020,10 @@ static PyObject * hash_get(PyObject * self, PyObject * args)
     return PyLong_FromLong(count);
 }
 
-static PyObject * count_trim_on_abundance(PyObject * self, PyObject * args)
+static
+PyObject *
+count_trim_on_abundance(khmer_KCountingHash_Object * me, PyObject * args)
 {
-    khmer_KCountingHashObject * me = (khmer_KCountingHashObject *) self;
     CountingHash * counting = me->counting;
 
     const char * seq = NULL;
@@ -1034,9 +1051,11 @@ static PyObject * count_trim_on_abundance(PyObject * self, PyObject * args)
 
     return ret;
 }
-static PyObject * count_trim_below_abundance(PyObject * self, PyObject * args)
+
+static
+PyObject *
+count_trim_below_abundance(khmer_KCountingHash_Object * me, PyObject * args)
 {
-    khmer_KCountingHashObject * me = (khmer_KCountingHashObject *) self;
     CountingHash * counting = me->counting;
 
     const char * seq = NULL;
@@ -1065,10 +1084,11 @@ static PyObject * count_trim_below_abundance(PyObject * self, PyObject * args)
     return ret;
 }
 
-static PyObject * count_find_spectral_error_positions(PyObject * self,
-        PyObject * args)
+static
+PyObject *
+count_find_spectral_error_positions(khmer_KCountingHash_Object * me,
+                                    PyObject * args)
 {
-    khmer_KCountingHashObject * me = (khmer_KCountingHashObject *) self;
     khmer::CountingHash * counting = me->counting;
 
     char * seq = NULL;
@@ -1100,10 +1120,11 @@ static PyObject * count_find_spectral_error_positions(PyObject * self,
     return x;
 }
 
-static PyObject * hash_fasta_count_kmers_by_position(PyObject * self,
-        PyObject * args)
+static
+PyObject *
+hash_fasta_count_kmers_by_position(khmer_KCountingHash_Object * me,
+                                   PyObject * args)
 {
-    khmer_KCountingHashObject * me = (khmer_KCountingHashObject *) self;
     CountingHash * counting = me->counting;
 
     const char * inputfile;
@@ -1152,10 +1173,11 @@ static PyObject * hash_fasta_count_kmers_by_position(PyObject * self,
     return x;
 }
 
-static PyObject * hash_fasta_dump_kmers_by_abundance(PyObject * self,
-        PyObject * args)
+static
+PyObject *
+hash_fasta_dump_kmers_by_abundance(khmer_KCountingHash_Object * me,
+                                   PyObject * args)
 {
-    khmer_KCountingHashObject * me = (khmer_KCountingHashObject *) self;
     CountingHash * counting = me->counting;
 
     const char * inputfile;
@@ -1171,9 +1193,10 @@ static PyObject * hash_fasta_dump_kmers_by_abundance(PyObject * self,
     Py_RETURN_NONE;
 }
 
-static PyObject * hash_load(PyObject * self, PyObject * args)
+static
+PyObject *
+hash_load(khmer_KCountingHash_Object * me, PyObject * args)
 {
-    khmer_KCountingHashObject * me = (khmer_KCountingHashObject *) self;
     CountingHash * counting = me->counting;
 
     const char * filename = NULL;
@@ -1192,9 +1215,10 @@ static PyObject * hash_load(PyObject * self, PyObject * args)
     Py_RETURN_NONE;
 }
 
-static PyObject * hash_save(PyObject * self, PyObject * args)
+static
+PyObject *
+hash_save(khmer_KCountingHash_Object * me, PyObject * args)
 {
-    khmer_KCountingHashObject * me = (khmer_KCountingHashObject *) self;
     CountingHash * counting = me->counting;
 
     const char * filename = NULL;
@@ -1208,9 +1232,10 @@ static PyObject * hash_save(PyObject * self, PyObject * args)
     Py_RETURN_NONE;
 }
 
-static PyObject * hash_get_ksize(PyObject * self, PyObject * args)
+static
+PyObject *
+hash_get_ksize(khmer_KCountingHash_Object * me, PyObject * args)
 {
-    khmer_KCountingHashObject * me = (khmer_KCountingHashObject *) self;
     CountingHash * counting = me->counting;
 
     if (!PyArg_ParseTuple(args, "")) {
@@ -1222,9 +1247,10 @@ static PyObject * hash_get_ksize(PyObject * self, PyObject * args)
     return PyLong_FromLong(k);
 }
 
-static PyObject * hash_get_hashsizes(PyObject * self, PyObject * args)
+static
+PyObject *
+hash_get_hashsizes(khmer_KCountingHash_Object * me, PyObject * args)
 {
-    khmer_KCountingHashObject * me = (khmer_KCountingHashObject *) self;
     CountingHash * counting = me->counting;
 
 
@@ -1242,12 +1268,15 @@ static PyObject * hash_get_hashsizes(PyObject * self, PyObject * args)
     return x;
 }
 
-static PyObject * hash_collect_high_abundance_kmers(PyObject * self,
-        PyObject * args);
+static
+PyObject *
+hash_collect_high_abundance_kmers(khmer_KCountingHash_Object * me,
+                                  PyObject * args);
 
-static PyObject * hash_consume_and_tag(PyObject * self, PyObject * args)
+static
+PyObject *
+hash_consume_and_tag(khmer_KCountingHash_Object * me, PyObject * args)
 {
-    khmer_KCountingHashObject * me = (khmer_KCountingHashObject *) self;
     CountingHash * counting = me->counting;
 
     const char * seq;
@@ -1270,9 +1299,10 @@ static PyObject * hash_consume_and_tag(PyObject * self, PyObject * args)
     return Py_BuildValue("K", n_consumed);
 }
 
-static PyObject * hash_get_tags_and_positions(PyObject * self, PyObject * args)
+static
+PyObject *
+hash_get_tags_and_positions(khmer_KCountingHash_Object * me, PyObject * args)
 {
-    khmer_KCountingHashObject * me = (khmer_KCountingHashObject *) self;
     CountingHash * counting = me->counting;
 
     const char * seq;
@@ -1307,9 +1337,10 @@ static PyObject * hash_get_tags_and_positions(PyObject * self, PyObject * args)
     return posns_list;
 }
 
-static PyObject * hash_find_all_tags_list(PyObject * self, PyObject *args)
+static
+PyObject *
+hash_find_all_tags_list(khmer_KCountingHash_Object * me, PyObject * args)
 {
-    khmer_KCountingHashObject * me = (khmer_KCountingHashObject *) self;
     CountingHash * counting = me->counting;
 
     const char * kmer_s = NULL;
@@ -1351,9 +1382,10 @@ static PyObject * hash_find_all_tags_list(PyObject * self, PyObject *args)
     return x;
 }
 
-static PyObject * hash_consume_fasta_and_tag(PyObject * self, PyObject * args)
+static
+PyObject *
+hash_consume_fasta_and_tag(khmer_KCountingHash_Object * me, PyObject * args)
 {
-    khmer_KCountingHashObject * me = (khmer_KCountingHashObject *) self;
     CountingHash * counting = me->counting;
 
     const char * filename;
@@ -1377,10 +1409,11 @@ static PyObject * hash_consume_fasta_and_tag(PyObject * self, PyObject * args)
     return Py_BuildValue("IK", total_reads, n_consumed);
 }
 
-static PyObject * hash_find_all_tags_truncate_on_abundance(PyObject * self,
-        PyObject *args)
+static
+PyObject *
+hash_find_all_tags_truncate_on_abundance(khmer_KCountingHash_Object * me,
+        PyObject * args)
 {
-    khmer_KCountingHashObject * me = (khmer_KCountingHashObject *) self;
     CountingHash * counting = me->counting;
 
     const char * kmer_s = NULL;
@@ -1420,10 +1453,11 @@ static PyObject * hash_find_all_tags_truncate_on_abundance(PyObject * self,
     return PyCObject_FromVoidPtr(ppi, free_pre_partition_info);
 }
 
-static PyObject * hash_do_subset_partition_with_abundance(PyObject * self,
-        PyObject * args)
+static
+PyObject *
+hash_do_subset_partition_with_abundance(khmer_KCountingHash_Object * me,
+                                        PyObject * args)
 {
-    khmer_KCountingHashObject * me = (khmer_KCountingHashObject *) self;
     CountingHash * counting = me->counting;
 
     HashIntoType start_kmer = 0, end_kmer = 0;
@@ -1477,82 +1511,101 @@ static PyObject * hash_do_subset_partition_with_abundance(PyObject * self,
 }
 
 static PyMethodDef khmer_counting_methods[] = {
-    { "ksize", hash_get_ksize, METH_VARARGS, "" },
-    { "hashsizes", hash_get_hashsizes, METH_VARARGS, "" },
-    { "set_use_bigcount", hash_set_use_bigcount, METH_VARARGS, "" },
-    { "get_use_bigcount", hash_get_use_bigcount, METH_VARARGS, "" },
-    { "n_unique_kmers", hash_n_unique_kmers, METH_VARARGS, "Count the number of unique kmers" },
-    { "n_occupied", hash_n_occupied, METH_VARARGS, "Count the number of occupied bins" },
-    { "n_entries", hash_n_entries, METH_VARARGS, "" },
-    { "count", hash_count, METH_VARARGS, "Count the given kmer" },
-    { "consume", hash_consume, METH_VARARGS, "Count all k-mers in the given string" },
-    { "consume_fasta", hash_consume_fasta, METH_VARARGS, "Count all k-mers in a given file" },
     {
-        "consume_fasta_with_reads_parser", hash_consume_fasta_with_reads_parser,
+        "ksize",
+        (PyCFunction)hash_get_ksize,
+        METH_VARARGS,
+        ""
+    },
+    { "hashsizes", (PyCFunction)hash_get_hashsizes, METH_VARARGS, "" },
+    { "set_use_bigcount", (PyCFunction)hash_set_use_bigcount, METH_VARARGS, "" },
+    { "get_use_bigcount", (PyCFunction)hash_get_use_bigcount, METH_VARARGS, "" },
+    { "n_unique_kmers", (PyCFunction)hash_n_unique_kmers, METH_VARARGS, "Count the number of unique kmers" },
+    { "n_occupied", (PyCFunction)hash_n_occupied, METH_VARARGS, "Count the number of occupied bins" },
+    { "n_entries", (PyCFunction)hash_n_entries, METH_VARARGS, "" },
+    { "count", (PyCFunction)hash_count, METH_VARARGS, "Count the given kmer" },
+    { "consume", (PyCFunction)hash_consume, METH_VARARGS, "Count all k-mers in the given string" },
+    { "consume_fasta", (PyCFunction)hash_consume_fasta, METH_VARARGS, "Count all k-mers in a given file" },
+    {
+        "consume_fasta_with_reads_parser", (PyCFunction)hash_consume_fasta_with_reads_parser,
         METH_VARARGS, "Count all k-mers using a given reads parser"
     },
-    { "output_fasta_kmer_pos_freq", hash_output_fasta_kmer_pos_freq, METH_VARARGS, "" },
-    { "get", hash_get, METH_VARARGS, "Get the count for the given k-mer" },
-    { "get_min_count", hash_get_min_count, METH_VARARGS, "Get the smallest count of all the k-mers in the string" },
-    { "get_max_count", hash_get_max_count, METH_VARARGS, "Get the largest count of all the k-mers in the string" },
-    { "get_median_count", hash_get_median_count, METH_VARARGS, "Get the median, average, and stddev of the k-mer counts in the string" },
-    { "get_kadian_count", hash_get_kadian_count, METH_VARARGS, "Get the kadian (abundance of k-th rank-ordered k-mer) of the k-mer counts in the string" },
-    { "trim_on_abundance", count_trim_on_abundance, METH_VARARGS, "Trim on >= abundance" },
-    { "trim_below_abundance", count_trim_below_abundance, METH_VARARGS, "Trim on >= abundance" },
-    { "find_spectral_error_positions", count_find_spectral_error_positions, METH_VARARGS, "Identify positions of low-abundance k-mers" },
-    { "abundance_distribution", hash_abundance_distribution, METH_VARARGS, "" },
-    { "abundance_distribution_with_reads_parser", hash_abundance_distribution_with_reads_parser, METH_VARARGS, "" },
-    { "fasta_count_kmers_by_position", hash_fasta_count_kmers_by_position, METH_VARARGS, "" },
-    { "fasta_dump_kmers_by_abundance", hash_fasta_dump_kmers_by_abundance, METH_VARARGS, "" },
-    { "load", hash_load, METH_VARARGS, "" },
-    { "save", hash_save, METH_VARARGS, "" },
+    { "output_fasta_kmer_pos_freq", (PyCFunction)hash_output_fasta_kmer_pos_freq, METH_VARARGS, "" },
+    { "get", (PyCFunction)hash_get, METH_VARARGS, "Get the count for the given k-mer" },
+    { "get_min_count", (PyCFunction)hash_get_min_count, METH_VARARGS, "Get the smallest count of all the k-mers in the string" },
+    { "get_max_count", (PyCFunction)hash_get_max_count, METH_VARARGS, "Get the largest count of all the k-mers in the string" },
+    { "get_median_count", (PyCFunction)hash_get_median_count, METH_VARARGS, "Get the median, average, and stddev of the k-mer counts in the string" },
+    { "get_kadian_count", (PyCFunction)hash_get_kadian_count, METH_VARARGS, "Get the kadian (abundance of k-th rank-ordered k-mer) of the k-mer counts in the string" },
+    { "trim_on_abundance", (PyCFunction)count_trim_on_abundance, METH_VARARGS, "Trim on >= abundance" },
+    { "trim_below_abundance", (PyCFunction)count_trim_below_abundance, METH_VARARGS, "Trim on >= abundance" },
+    { "find_spectral_error_positions", (PyCFunction)count_find_spectral_error_positions, METH_VARARGS, "Identify positions of low-abundance k-mers" },
+    { "abundance_distribution", (PyCFunction)hash_abundance_distribution, METH_VARARGS, "" },
+    { "abundance_distribution_with_reads_parser", (PyCFunction)hash_abundance_distribution_with_reads_parser, METH_VARARGS, "" },
+    { "fasta_count_kmers_by_position", (PyCFunction)hash_fasta_count_kmers_by_position, METH_VARARGS, "" },
+    { "fasta_dump_kmers_by_abundance", (PyCFunction)hash_fasta_dump_kmers_by_abundance, METH_VARARGS, "" },
+    { "load", (PyCFunction)hash_load, METH_VARARGS, "" },
+    { "save", (PyCFunction)hash_save, METH_VARARGS, "" },
     {
-        "collect_high_abundance_kmers", hash_collect_high_abundance_kmers,
+        "collect_high_abundance_kmers", (PyCFunction)hash_collect_high_abundance_kmers,
         METH_VARARGS, ""
     },
-    { "consume_and_tag", hash_consume_and_tag, METH_VARARGS, "Consume a sequence and tag it" },
-    { "get_tags_and_positions", hash_get_tags_and_positions, METH_VARARGS, "Retrieve tags and their positions in a sequence." },
-    { "find_all_tags_list", hash_find_all_tags_list, METH_VARARGS, "Find all tags within range of the given k-mer, return as list" },
-    { "consume_fasta_and_tag", hash_consume_fasta_and_tag, METH_VARARGS, "Count all k-mers in a given file" },
-    { "do_subset_partition_with_abundance", hash_do_subset_partition_with_abundance, METH_VARARGS, "" },
-    { "find_all_tags_truncate_on_abundance", hash_find_all_tags_truncate_on_abundance, METH_VARARGS, "" },
+    { "consume_and_tag", (PyCFunction)hash_consume_and_tag, METH_VARARGS, "Consume a sequence and tag it" },
+    { "get_tags_and_positions", (PyCFunction)hash_get_tags_and_positions, METH_VARARGS, "Retrieve tags and their positions in a sequence." },
+    { "find_all_tags_list", (PyCFunction)hash_find_all_tags_list, METH_VARARGS, "Find all tags within range of the given k-mer, return as list" },
+    { "consume_fasta_and_tag", (PyCFunction)hash_consume_fasta_and_tag, METH_VARARGS, "Count all k-mers in a given file" },
+    { "do_subset_partition_with_abundance", (PyCFunction)hash_do_subset_partition_with_abundance, METH_VARARGS, "" },
+    { "find_all_tags_truncate_on_abundance", (PyCFunction)hash_find_all_tags_truncate_on_abundance, METH_VARARGS, "" },
 
     {NULL, NULL, 0, NULL}           /* sentinel */
 };
 
-#define is_counting_obj(v)  (Py_TYPE(v) == &khmer_KCountingHashType)
+static PyObject* _new_counting_hash(PyTypeObject * type, PyObject * args,
+                                    PyObject * kwds);
 
-static PyTypeObject khmer_KCountingHashType
-CPYCHECKER_TYPE_OBJECT_FOR_TYPEDEF("khmer_KCountingHashObject")
+static PyTypeObject khmer_KCountingHash_Type
+CPYCHECKER_TYPE_OBJECT_FOR_TYPEDEF("khmer_KCountingHash_Object")
 = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    "KCountingHash", sizeof(khmer_KCountingHashObject),
-    0,
-    khmer_counting_dealloc, /*tp_dealloc*/
-    0,              /*tp_print*/
-    0,              /*tp_getattr*/
-    0,              /*tp_setattr*/
-    0,              /*tp_compare*/
-    0,              /*tp_repr*/
-    0,              /*tp_as_number*/
-    0,              /*tp_as_sequence*/
-    0,              /*tp_as_mapping*/
-    0,              /*tp_hash */
-    0,              /*tp_call*/
-    0,              /*tp_str*/
-    0,              /*tp_getattro*/
-    0,              /*tp_setattro*/
-    0,              /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT,     /*tp_flags*/
-    "counting hash object",           /* tp_doc */
-    0,                       /* tp_traverse */
-    0,                       /* tp_clear */
-    0,                       /* tp_richcompare */
-    0,                       /* tp_weaklistoffset */
-    0,                       /* tp_iter */
-    0,                       /* tp_iternext */
-    khmer_counting_methods,  /* tp_methods */
+    PyVarObject_HEAD_INIT(NULL, 0)       /* init & ob_size */
+    "_khmer.KCountingHash",              /*tp_name*/
+    sizeof(khmer_KCountingHash_Object),  /*tp_basicsize*/
+    0,                                   /*tp_itemsize*/
+    (destructor)khmer_counting_dealloc,  /*tp_dealloc*/
+    0,                                   /*tp_print*/
+    0,                                   /*tp_getattr*/
+    0,                                   /*tp_setattr*/
+    0,                                   /*tp_compare*/
+    0,                                   /*tp_repr*/
+    0,                                   /*tp_as_number*/
+    0,                                   /*tp_as_sequence*/
+    0,                                   /*tp_as_mapping*/
+    0,                                   /*tp_hash */
+    0,                                   /*tp_call*/
+    0,                                   /*tp_str*/
+    0,                                   /*tp_getattro*/
+    0,                                   /*tp_setattro*/
+    0,                                   /*tp_as_buffer*/
+    Py_TPFLAGS_DEFAULT,                  /*tp_flags*/
+    "counting hash object",              /* tp_doc */
+    0,                                   /* tp_traverse */
+    0,                                   /* tp_clear */
+    0,                                   /* tp_richcompare */
+    0,                                   /* tp_weaklistoffset */
+    0,                                   /* tp_iter */
+    0,                                   /* tp_iternext */
+    khmer_counting_methods,              /* tp_methods */
+    0,                                   /* tp_members */
+    0,                                   /* tp_getset */
+    0,                                   /* tp_base */
+    0,                                   /* tp_dict */
+    0,                                   /* tp_descr_get */
+    0,                                   /* tp_descr_set */
+    0,                                   /* tp_dictoffset */
+    0,                                   /* tp_init */
+    0,                                   /* tp_alloc */
+    _new_counting_hash,                  /* tp_new */
 };
+
+#define is_counting_obj(v)  (Py_TYPE(v) == &khmer_KCountingHash_Type)
 
 //
 // new_hashtable
@@ -1567,8 +1620,8 @@ static PyObject* new_hashtable(PyObject * self, PyObject * args)
         return NULL;
     }
 
-    khmer_KCountingHashObject * kcounting_obj = (khmer_KCountingHashObject *) \
-            PyObject_New(khmer_KCountingHashObject, &khmer_KCountingHashType);
+    khmer_KCountingHash_Object * kcounting_obj = (khmer_KCountingHash_Object *) \
+            PyObject_New(khmer_KCountingHash_Object, &khmer_KCountingHash_Type);
 
     if (kcounting_obj == NULL) {
         return NULL;
@@ -1587,50 +1640,53 @@ static PyObject* new_hashtable(PyObject * self, PyObject * args)
 // new_counting_hash
 //
 
-static PyObject* _new_counting_hash(PyObject * self, PyObject * args)
+static PyObject* _new_counting_hash(PyTypeObject * type, PyObject * args,
+                                    PyObject * kwds)
 {
-    WordLength k = 0;
-    PyListObject * sizes_list_o = NULL;
+    khmer_KCountingHash_Object * self;
 
-    if (!PyArg_ParseTuple(args, "bO!", &k, &PyList_Type, &sizes_list_o)) {
-        return NULL;
-    }
+    self = (khmer_KCountingHash_Object *)type->tp_alloc(type, 0);
 
-    std::vector<HashIntoType> sizes;
-    Py_ssize_t sizes_list_o_length = PyList_GET_SIZE(sizes_list_o);
-    if (sizes_list_o_length == -1) {
-        PyErr_SetString(PyExc_ValueError, "error with hashtable primes!");
-        return NULL;
-    }
-    for (Py_ssize_t i = 0; i < sizes_list_o_length; i++) {
-        PyObject * size_o = PyList_GET_ITEM(sizes_list_o, i);
-        if (PyLong_Check(size_o)) {
-            sizes.push_back((HashIntoType) PyLong_AsUnsignedLongLong(size_o));
-        } else if (PyInt_Check(size_o)) {
-            sizes.push_back((HashIntoType) PyInt_AsLong(size_o));
-        } else if (PyFloat_Check(size_o)) {
-            sizes.push_back((HashIntoType) PyFloat_AS_DOUBLE(size_o));
-        } else {
-            PyErr_SetString(PyExc_TypeError,
-                            "2nd argument must be a list of ints, longs, or floats");
+    if (self != NULL) {
+        WordLength k = 0;
+        PyListObject * sizes_list_o = NULL;
+
+        if (!PyArg_ParseTuple(args, "bO!", &k, &PyList_Type, &sizes_list_o)) {
+            Py_DECREF(self);
             return NULL;
+        }
+
+        std::vector<HashIntoType> sizes;
+        Py_ssize_t sizes_list_o_length = PyList_GET_SIZE(sizes_list_o);
+        if (sizes_list_o_length == -1) {
+            Py_DECREF(self);
+            PyErr_SetString(PyExc_ValueError, "error with hashtable primes!");
+            return NULL;
+        }
+        for (Py_ssize_t i = 0; i < sizes_list_o_length; i++) {
+            PyObject * size_o = PyList_GET_ITEM(sizes_list_o, i);
+            if (PyLong_Check(size_o)) {
+                sizes.push_back((HashIntoType) PyLong_AsUnsignedLongLong(size_o));
+            } else if (PyInt_Check(size_o)) {
+                sizes.push_back((HashIntoType) PyInt_AsLong(size_o));
+            } else if (PyFloat_Check(size_o)) {
+                sizes.push_back((HashIntoType) PyFloat_AS_DOUBLE(size_o));
+            } else {
+                Py_DECREF(self);
+                PyErr_SetString(PyExc_TypeError,
+                                "2nd argument must be a list of ints, longs, or floats");
+                return NULL;
+            }
+        }
+
+        try {
+            self->counting = new CountingHash(k, sizes);
+        } catch (std::bad_alloc &e) {
+            return PyErr_NoMemory();
         }
     }
 
-    khmer_KCountingHashObject * kcounting_obj = (khmer_KCountingHashObject *) \
-            PyObject_New(khmer_KCountingHashObject, &khmer_KCountingHashType);
-
-    if (kcounting_obj == NULL) {
-        return NULL;
-    }
-
-    try {
-        kcounting_obj->counting = new CountingHash(k, sizes);
-    } catch (std::bad_alloc &e) {
-        return PyErr_NoMemory();
-    }
-
-    return (PyObject *) kcounting_obj;
+    return (PyObject *) self;
 }
 
 //
@@ -1684,11 +1740,11 @@ CPYCHECKER_TYPE_OBJECT_FOR_TYPEDEF("khmer_KHashbitsObject")
     0,                       /* tp_alloc */
 };
 
-static PyObject * hash_abundance_distribution_with_reads_parser(
-    PyObject * self,
-    PyObject * args)
+static
+PyObject *
+hash_abundance_distribution_with_reads_parser(khmer_KCountingHash_Object * me,
+        PyObject * args)
 {
-    khmer_KCountingHashObject * me = (khmer_KCountingHashObject *) self;
     CountingHash * counting = me->counting;
 
     khmer :: python :: khmer_ReadParser_Object * rparser_obj = NULL;
@@ -1731,9 +1787,10 @@ static PyObject * hash_abundance_distribution_with_reads_parser(
     return x;
 }
 
-static PyObject * hash_abundance_distribution(PyObject * self, PyObject * args)
+static
+PyObject *
+hash_abundance_distribution(khmer_KCountingHash_Object * me, PyObject * args)
 {
-    khmer_KCountingHashObject * me = (khmer_KCountingHashObject *) self;
     CountingHash * counting = me->counting;
 
     const char * filename = NULL;
@@ -1984,10 +2041,10 @@ static PyObject * hashbits_traverse_from_tags(PyObject * self, PyObject * args)
     khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
     Hashbits * hashbits = me->hashbits;
 
-    khmer_KCountingHashObject * counting_o = NULL;
+    khmer_KCountingHash_Object * counting_o = NULL;
     unsigned int distance, threshold, frequency;
 
-    if (!PyArg_ParseTuple(args, "O!III", &khmer_KCountingHashType, &counting_o,
+    if (!PyArg_ParseTuple(args, "O!III", &khmer_KCountingHash_Type, &counting_o,
                           &distance, &threshold, &frequency)) {
         return NULL;
     }
@@ -2004,11 +2061,11 @@ static PyObject * hashbits_repartition_largest_partition(PyObject * self,
     khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
     Hashbits * hashbits = me->hashbits;
 
-    khmer_KCountingHashObject * counting_o = NULL;
+    khmer_KCountingHash_Object * counting_o = NULL;
     PyObject * subset_o = NULL;
     unsigned int distance, threshold, frequency;
 
-    if (!PyArg_ParseTuple(args, "OO!III", &subset_o, &khmer_KCountingHashType,
+    if (!PyArg_ParseTuple(args, "OO!III", &subset_o, &khmer_KCountingHash_Type,
                           &counting_o, &distance, &threshold, &frequency)) {
         return NULL;
     }
@@ -2335,11 +2392,11 @@ static PyObject * hashbits_consume_fasta_and_traverse(PyObject * self,
 
     const char * filename;
     unsigned int radius, big_threshold, transfer_threshold;
-    khmer_KCountingHashObject * counting_o = NULL;
+    khmer_KCountingHash_Object * counting_o = NULL;
 
     if (!PyArg_ParseTuple(args, "sIIIO!", &filename,
                           &radius, &big_threshold, &transfer_threshold,
-                          &khmer_KCountingHashType, &counting_o)) {
+                          &khmer_KCountingHash_Type, &counting_o)) {
         return NULL;
     }
 
@@ -3522,9 +3579,9 @@ subset_partition_average_coverages(khmer_KSubsetPartition_Object * me,
 {
     SubsetPartition * subset_p = me->subset;
 
-    khmer_KCountingHashObject * counting_o;
+    khmer_KCountingHash_Object * counting_o;
 
-    if (!PyArg_ParseTuple(args, "O!", &khmer_KCountingHashType, &counting_o)) {
+    if (!PyArg_ParseTuple(args, "O!", &khmer_KCountingHash_Type, &counting_o)) {
         return NULL;
     }
 
@@ -4079,11 +4136,11 @@ static PyObject* khmer_ReadAligner_new(PyTypeObject *type, PyObject * args,
     self = (khmer_ReadAligner_Object *)type->tp_alloc(type, 0);
 
     if (self != NULL) {
-        khmer_KCountingHashObject * ch = NULL;
+        khmer_KCountingHash_Object * ch = NULL;
         unsigned short int trusted_cov_cutoff = 2;
         double bits_theta = 1;
 
-        if(!PyArg_ParseTuple(args, "O!Hd", &khmer_KCountingHashType, &ch,
+        if(!PyArg_ParseTuple(args, "O!Hd", &khmer_KCountingHash_Type, &ch,
                              &trusted_cov_cutoff, &bits_theta)) {
             Py_DECREF(self);
             return NULL;
@@ -4185,10 +4242,9 @@ static PyObject* _new_hashbits(PyObject * self, PyObject * args)
     return (PyObject *) khashbits_obj;
 }
 
-static PyObject * hash_collect_high_abundance_kmers(PyObject * self,
-        PyObject * args)
+static PyObject * hash_collect_high_abundance_kmers(khmer_KCountingHash_Object *
+        me , PyObject * args)
 {
-    khmer_KCountingHashObject * me = (khmer_KCountingHashObject *) self;
     CountingHash * counting = me->counting;
 
     const char * filename = NULL;
@@ -4227,13 +4283,11 @@ static PyObject * hash_collect_high_abundance_kmers(PyObject * self,
 // khmer_counting_dealloc -- clean up a counting hash object.
 //
 
-static void khmer_counting_dealloc(PyObject* self)
+static void khmer_counting_dealloc(khmer_KCountingHash_Object * obj)
 {
-    khmer_KCountingHashObject * obj = (khmer_KCountingHashObject *) self;
     delete obj->counting;
     obj->counting = NULL;
-
-    PyObject_Del((PyObject *) obj);
+    Py_TYPE(obj)->tp_free((PyObject*)obj);
 }
 
 //
@@ -4586,10 +4640,6 @@ static PyMethodDef KhmerMethods[] = {
         METH_VARARGS,       "Create an empty single-table counting hash"
     },
     {
-        "_new_counting_hash",   _new_counting_hash,
-        METH_VARARGS,       "Create an empty counting hash"
-    },
-    {
         "_new_hashbits",        _new_hashbits,
         METH_VARARGS,       "Create an empty hashbits table"
     },
@@ -4631,7 +4681,7 @@ init_khmer(void)
 {
     using namespace python;
 
-    if (PyType_Ready(&khmer_KCountingHashType) < 0) {
+    if (PyType_Ready(&khmer_KCountingHash_Type) < 0) {
         return;
     }
 
@@ -4689,6 +4739,12 @@ init_khmer(void)
     Py_INCREF(&khmer_ReadParser_Type);
     if (PyModule_AddObject( m, "ReadParser",
                             (PyObject *)&khmer_ReadParser_Type ) < 0) {
+        return;
+    }
+
+    Py_INCREF(&khmer_KCountingHash_Type);
+    if (PyModule_AddObject( m, "CountingHash",
+                            (PyObject *)&khmer_KCountingHash_Type ) < 0) {
         return;
     }
 

--- a/khmer/_khmermodule.cc
+++ b/khmer/_khmermodule.cc
@@ -673,7 +673,6 @@ typedef struct {
 } khmer_KHashbitsObject;
 
 static void khmer_subset_dealloc(PyObject *);
-static PyObject * khmer_subset_getattr(PyObject * obj, char * name);
 
 static PyTypeObject khmer_KSubsetPartitionType = {
     PyVarObject_HEAD_INIT(NULL, 0)
@@ -681,7 +680,7 @@ static PyTypeObject khmer_KSubsetPartitionType = {
     0,
     khmer_subset_dealloc,   /*tp_dealloc*/
     0,              /*tp_print*/
-    khmer_subset_getattr,   /*tp_getattr*/
+    0,              /*tp_getattr*/
     0,              /*tp_setattr*/
     0,              /*tp_compare*/
     0,              /*tp_repr*/
@@ -1552,12 +1551,6 @@ static PyMethodDef khmer_counting_methods[] = {
     {NULL, NULL, 0, NULL}           /* sentinel */
 };
 
-static PyObject *
-khmer_counting_getattr(PyObject * obj, char * name)
-{
-    return Py_FindMethod(khmer_counting_methods, obj, name);
-}
-
 #define is_counting_obj(v)  (Py_TYPE(v) == &khmer_KCountingHashType)
 
 static PyTypeObject khmer_KCountingHashType
@@ -1568,7 +1561,7 @@ CPYCHECKER_TYPE_OBJECT_FOR_TYPEDEF("khmer_KCountingHashObject")
     0,
     khmer_counting_dealloc, /*tp_dealloc*/
     0,              /*tp_print*/
-    khmer_counting_getattr, /*tp_getattr*/
+    0,              /*tp_getattr*/
     0,              /*tp_setattr*/
     0,              /*tp_compare*/
     0,              /*tp_repr*/
@@ -1583,6 +1576,13 @@ CPYCHECKER_TYPE_OBJECT_FOR_TYPEDEF("khmer_KCountingHashObject")
     0,              /*tp_as_buffer*/
     Py_TPFLAGS_DEFAULT,     /*tp_flags*/
     "counting hash object",           /* tp_doc */
+    0,                       /* tp_traverse */
+    0,                       /* tp_clear */
+    0,                       /* tp_richcompare */
+    0,                       /* tp_weaklistoffset */
+    0,                       /* tp_iter */
+    0,                       /* tp_iternext */
+    khmer_counting_methods,  /* tp_methods */
 };
 
 //
@@ -1673,7 +1673,6 @@ static PyObject* khmer_hashbits_new(PyTypeObject * type, PyObject * args,
                                     PyObject * kwds);
 static int khmer_hashbits_init(khmer_KHashbitsObject * self, PyObject * args,
                                PyObject * kwds);
-static PyObject * khmer_hashbits_getattr(PyObject * obj, char * name);
 
 static PyTypeObject khmer_KHashbitsType
 CPYCHECKER_TYPE_OBJECT_FOR_TYPEDEF("khmer_KHashbitsObject")
@@ -1683,7 +1682,7 @@ CPYCHECKER_TYPE_OBJECT_FOR_TYPEDEF("khmer_KHashbitsObject")
     0,
     (destructor)khmer_hashbits_dealloc, /*tp_dealloc*/
     0,              /*tp_print*/
-    khmer_hashbits_getattr, /*tp_getattr*/
+    0,              /*tp_getattr*/
     0,              /*tp_setattr*/
     0,              /*tp_compare*/
     0,              /*tp_repr*/
@@ -3348,12 +3347,6 @@ static PyMethodDef khmer_hashbits_methods[] = {
     {NULL, NULL, 0, NULL}           /* sentinel */
 };
 
-static PyObject *
-khmer_hashbits_getattr(PyObject * obj, char * name)
-{
-    return Py_FindMethod(khmer_hashbits_methods, obj, name);
-}
-
 // __new__ for hashbits; necessary for proper subclassing
 // This will essentially do what the old factory function did. Unlike many __new__
 // methods, we take our arguments here, because there's no "uninitialized" hashbits
@@ -3595,12 +3588,6 @@ static PyMethodDef khmer_subset_methods[] = {
     { "partition_average_coverages", subset_partition_average_coverages, METH_VARARGS, "" },
     {NULL, NULL, 0, NULL}           /* sentinel */
 };
-
-static PyObject *
-khmer_subset_getattr(PyObject * obj, char * name)
-{
-    return Py_FindMethod(khmer_subset_methods, obj, name);
-}
 
 /////////////////
 // LabelHash
@@ -4115,7 +4102,7 @@ static PyTypeObject khmer_ReadAlignerType = {
     0,					    /*tp_itemsize*/
     (destructor)khmer_readaligner_dealloc,  /*tp_dealloc*/
     0,                          /*tp_print*/
-    0,			        /*tp_getattr*/
+    0,                          /*tp_getattr*/
     0,                          /*tp_setattr*/
     0,                          /*tp_compare*/
     0,                          /*tp_repr*/
@@ -4130,21 +4117,21 @@ static PyTypeObject khmer_ReadAlignerType = {
     0,                          /*tp_as_buffer*/
     Py_TPFLAGS_DEFAULT,         /*tp_flags*/
     "ReadAligner object",           /* tp_doc */
-    0,		               /* tp_traverse */
-    0,		               /* tp_clear */
-    0,		               /* tp_richcompare */
-    0,		               /* tp_weaklistoffset */
-    0,		               /* tp_iter */
-    0,		               /* tp_iternext */
-    khmer_ReadAligner_methods,  /* tp_methods */
-    0,             /* tp_members */
+    0,                         /* tp_traverse */
+    0,                         /* tp_clear */
+    0,                         /* tp_richcompare */
+    0,                         /* tp_weaklistoffset */
+    0,                         /* tp_iter */
+    0,                         /* tp_iternext */
+    khmer_ReadAligner_methods, /* tp_methods */
+    0,                         /* tp_members */
     0,                         /* tp_getset */
     0,                         /* tp_base */
     0,                         /* tp_dict */
     0,                         /* tp_descr_get */
     0,                         /* tp_descr_set */
     0,                         /* tp_dictoffset */
-    0,			       /* tp_init */
+    0,			               /* tp_init */
     0,                         /* tp_alloc */
     khmer_ReadAligner_new,     /* tp_new */
 };
@@ -4645,7 +4632,14 @@ init_khmer(void)
 {
     using namespace python;
 
-    khmer_KCountingHashType.ob_type   = &PyType_Type;
+    if (PyType_Ready(&khmer_KCountingHashType) < 0) {
+        return;
+    }
+
+    khmer_KSubsetPartitionType.tp_methods = khmer_subset_methods;
+    if (PyType_Ready(&khmer_KSubsetPartitionType) < 0) {
+        return;
+    }
 
     // implemented __new__ for Hashbits; keeping factory func around as well
     // for backwards compat with old scripts
@@ -4659,6 +4653,10 @@ init_khmer(void)
     khmer_KLabelHashType.tp_base = &khmer_KHashbitsType;
     khmer_KLabelHashType.tp_new = khmer_labelhash_new;
     if (PyType_Ready(&khmer_KLabelHashType) < 0) {
+        return;
+    }
+
+    if (PyType_Ready(&khmer_ReadAlignerType) < 0) {
         return;
     }
 

--- a/khmer/_khmermodule.cc
+++ b/khmer/_khmermodule.cc
@@ -428,33 +428,33 @@ _ReadPairIterator_iternext(khmer_ReadPairIterator_Object * myself)
 }
 
 static PyTypeObject khmer_ReadPairIterator_Type = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    "khmer.ReadPairIterator",                       /* tp_name */
-    sizeof(khmer_ReadPairIterator_Object),          /* tp_basicsize */
-    0,                                  /* tp_itemsize */
-    (destructor)khmer_ReadPairIterator_dealloc,      /* tp_dealloc */
-    0,                                         /* tp_print */
-    0,                                         /* tp_getattr */
-    0,                                         /* tp_setattr */
-    0,                                         /* tp_compare */
-    0,                                         /* tp_repr */
-    0,                                         /* tp_as_number */
-    0,                                         /* tp_as_sequence */
-    0,                                         /* tp_as_mapping */
-    0,                                         /* tp_hash */
-    0,                                         /* tp_call */
-    0,                                         /* tp_str */
-    0,                                         /* tp_getattro */
-    0,                                         /* tp_setattro */
-    0,                                         /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT,  /* tp_flags */
-    "Iterates over 'ReadParser' objects and returns read pairs.",      /* tp_doc */
-    0,                                         /* tp_traverse */
-    0,                                         /* tp_clear */
-    0,                                         /* tp_richcompare */
-    0,                                         /* tp_weaklistoffset */
-    PyObject_SelfIter,                                         /* tp_iter */
-    (iternextfunc)_ReadPairIterator_iternext,                                         /* tp_iternext */
+    PyVarObject_HEAD_INIT(NULL, 0)              /* init & ob_size */
+    "khmer.ReadPairIterator",                   /* tp_name */
+    sizeof(khmer_ReadPairIterator_Object),      /* tp_basicsize */
+    0,                                          /* tp_itemsize */
+    (destructor)khmer_ReadPairIterator_dealloc, /* tp_dealloc */
+    0,                                          /* tp_print */
+    0,                                          /* tp_getattr */
+    0,                                          /* tp_setattr */
+    0,                                          /* tp_compare */
+    0,                                          /* tp_repr */
+    0,                                          /* tp_as_number */
+    0,                                          /* tp_as_sequence */
+    0,                                          /* tp_as_mapping */
+    0,                                          /* tp_hash */
+    0,                                          /* tp_call */
+    0,                                          /* tp_str */
+    0,                                          /* tp_getattro */
+    0,                                          /* tp_setattro */
+    0,                                          /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT,                         /* tp_flags */
+    "Iterates over 'ReadParser' objects and returns read pairs.", /* tp_doc */
+    0,                                          /* tp_traverse */
+    0,                                          /* tp_clear */
+    0,                                          /* tp_richcompare */
+    0,                                          /* tp_weaklistoffset */
+    PyObject_SelfIter,                          /* tp_iter */
+    (iternextfunc)_ReadPairIterator_iternext,   /* tp_iternext */
 };
 
 

--- a/khmer/_khmermodule.cc
+++ b/khmer/_khmermodule.cc
@@ -638,7 +638,7 @@ typedef struct {
 typedef struct {
     PyObject_HEAD
     Hashbits * hashbits;
-} khmer_KHashbitsObject;
+} khmer_KHashbits_Object;
 
 static void khmer_subset_dealloc(khmer_KSubsetPartition_Object * obj);
 
@@ -1693,18 +1693,19 @@ static PyObject* _new_counting_hash(PyTypeObject * type, PyObject * args,
 // hashbits stuff
 //
 
-static void khmer_hashbits_dealloc(PyObject * obj);
+static void khmer_hashbits_dealloc(khmer_KHashbits_Object * obj);
 static PyObject* khmer_hashbits_new(PyTypeObject * type, PyObject * args,
                                     PyObject * kwds);
-static int khmer_hashbits_init(khmer_KHashbitsObject * self, PyObject * args,
+static int khmer_hashbits_init(khmer_KHashbits_Object * self, PyObject * args,
                                PyObject * kwds);
 
-static PyTypeObject khmer_KHashbitsType
-CPYCHECKER_TYPE_OBJECT_FOR_TYPEDEF("khmer_KHashbitsObject")
+static PyTypeObject khmer_KHashbits_Type
+CPYCHECKER_TYPE_OBJECT_FOR_TYPEDEF("khmer_KHashbits_Object")
 = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    "Hashbits", sizeof(khmer_KHashbitsObject),
-    0,
+    PyVarObject_HEAD_INIT(NULL, 0) /* init & ob_size */
+    "_khmer.Hashbits",             /* tp_name */
+    sizeof(khmer_KHashbits_Object), /* tp_basicsize */
+    0,                             /* tp_itemsize */
     (destructor)khmer_hashbits_dealloc, /*tp_dealloc*/
     0,              /*tp_print*/
     0,              /*tp_getattr*/
@@ -1738,6 +1739,7 @@ CPYCHECKER_TYPE_OBJECT_FOR_TYPEDEF("khmer_KHashbitsObject")
     0,                       /* tp_dictoffset */
     (initproc)khmer_hashbits_init,   /* tp_init */
     0,                       /* tp_alloc */
+    khmer_hashbits_new,                  /* tp_new */
 };
 
 static
@@ -1748,10 +1750,10 @@ hash_abundance_distribution_with_reads_parser(khmer_KCountingHash_Object * me,
     CountingHash * counting = me->counting;
 
     khmer :: python :: khmer_ReadParser_Object * rparser_obj = NULL;
-    khmer_KHashbitsObject *tracking_obj = NULL;
+    khmer_KHashbits_Object *tracking_obj = NULL;
 
     if (!PyArg_ParseTuple(args, "O!O!", &python::khmer_ReadParser_Type,
-                          &rparser_obj, &khmer_KHashbitsType, &tracking_obj)) {
+                          &rparser_obj, &khmer_KHashbits_Type, &tracking_obj)) {
         return NULL;
     }
 
@@ -1794,8 +1796,8 @@ hash_abundance_distribution(khmer_KCountingHash_Object * me, PyObject * args)
     CountingHash * counting = me->counting;
 
     const char * filename = NULL;
-    khmer_KHashbitsObject * tracking_obj = NULL;
-    if (!PyArg_ParseTuple(args, "sO!", &filename, &khmer_KHashbitsType,
+    khmer_KHashbits_Object * tracking_obj = NULL;
+    if (!PyArg_ParseTuple(args, "sO!", &filename, &khmer_KHashbits_Type,
                           &tracking_obj)) {
         return NULL;
     }
@@ -1833,9 +1835,10 @@ hash_abundance_distribution(khmer_KCountingHash_Object * me, PyObject * args)
     return x;
 }
 
-static PyObject * hashbits_n_unique_kmers(PyObject * self, PyObject * args)
+static
+PyObject *
+hashbits_n_unique_kmers(khmer_KHashbits_Object * me, PyObject * args)
 {
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
     Hashbits * hashbits = me->hashbits;
 
     HashIntoType n = hashbits->n_unique_kmers();
@@ -1844,580 +1847,599 @@ static PyObject * hashbits_n_unique_kmers(PyObject * self, PyObject * args)
 }
 
 
-static PyObject * hashbits_count_overlap(PyObject * self, PyObject * args)
+static
+PyObject *
+hashbits_count_overlap(khmer_KHashbits_Object * me, PyObject * args)
 {
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
     Hashbits * hashbits = me->hashbits;
-    khmer_KHashbitsObject * ht2_argu;
+    khmer_KHashbits_Object * ht2_argu;
     const char * filename;
     Hashbits * ht2;
 
-    if (!PyArg_ParseTuple(args, "sO!", &filename, &khmer_KHashbitsType,
+    if (!PyArg_ParseTuple(args, "sO!", &filename, &khmer_KHashbits_Type,
                           &ht2_argu)) {
-        return NULL;
-    }
-
-    ht2 = ht2_argu->hashbits;
-
-    // call the C++ function, and trap signals => Python
-
-    unsigned long long n_consumed;
-    unsigned int total_reads;
-    HashIntoType curve[2][100];
-
-    try {
-        hashbits->consume_fasta_overlap(filename, curve, *ht2, total_reads, n_consumed);
-    } catch (_khmer_signal &e) {
-        PyErr_SetString(PyExc_IOError, e.get_message().c_str());
-        return NULL;
-    }
-
-    HashIntoType n = hashbits->n_unique_kmers();
-    HashIntoType n_overlap = hashbits->n_overlap_kmers();
-
-    PyObject * x = PyList_New(200);
-
-    for (unsigned int i = 0; i < 100; i++) {
-        PyList_SetItem(x, i, Py_BuildValue("K", curve[0][i]));
-    }
-    for (unsigned int i = 0; i < 100; i++) {
-        PyList_SetItem(x, i + 100, Py_BuildValue("K", curve[1][i]));
-    }
-    return Py_BuildValue("KKO", n, n_overlap, x);
+    return NULL;
 }
 
-static PyObject * hashbits_n_occupied(PyObject * self, PyObject * args)
-{
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
-    Hashbits * hashbits = me->hashbits;
+ht2 = ht2_argu->hashbits;
 
-    HashIntoType start = 0, stop = 0;
+// call the C++ function, and trap signals => Python
 
-    if (!PyArg_ParseTuple(args, "|KK", &start, &stop)) {
-        return NULL;
-    }
+unsigned long long n_consumed;
+unsigned int total_reads;
+HashIntoType curve[2][100];
 
-    HashIntoType n = hashbits->n_occupied(start, stop);
-
-    return PyLong_FromUnsignedLongLong(n);
+try {
+    hashbits->consume_fasta_overlap(filename, curve, *ht2, total_reads, n_consumed);
+} catch (_khmer_signal &e) {
+    PyErr_SetString(PyExc_IOError, e.get_message().c_str());
+    return NULL;
 }
 
-static PyObject * hashbits_n_tags(PyObject * self, PyObject * args)
-{
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
-    Hashbits * hashbits = me->hashbits;
+HashIntoType n = hashbits->n_unique_kmers();
+HashIntoType n_overlap = hashbits->n_overlap_kmers();
 
-    if (!PyArg_ParseTuple(args, "")) {
-        return NULL;
-    }
+PyObject * x = PyList_New(200);
 
-    return PyLong_FromSize_t(hashbits->n_tags());
+for (unsigned int i = 0; i < 100; i++) {
+    PyList_SetItem(x, i, Py_BuildValue("K", curve[0][i]));
+}
+for (unsigned int i = 0; i < 100; i++) {
+    PyList_SetItem(x, i + 100, Py_BuildValue("K", curve[1][i]));
+}
+return Py_BuildValue("KKO", n, n_overlap, x);
 }
 
-static PyObject * hashbits_count(PyObject * self, PyObject * args)
+static
+PyObject *
+hashbits_n_occupied(khmer_KHashbits_Object * me, PyObject * args)
 {
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
-    Hashbits * hashbits = me->hashbits;
+Hashbits * hashbits = me->hashbits;
 
-    const char * kmer;
+HashIntoType start = 0, stop = 0;
 
-    if (!PyArg_ParseTuple(args, "s", &kmer)) {
-        return NULL;
-    }
+if (!PyArg_ParseTuple(args, "|KK", &start, &stop)) {
+    return NULL;
+}
 
-    if (strlen(kmer) != hashbits->ksize()) {
+HashIntoType n = hashbits->n_occupied(start, stop);
+
+return PyLong_FromUnsignedLongLong(n);
+}
+
+static
+PyObject *
+hashbits_n_tags(khmer_KHashbits_Object * me, PyObject * args)
+{
+Hashbits * hashbits = me->hashbits;
+
+if (!PyArg_ParseTuple(args, "")) {
+    return NULL;
+}
+
+return PyLong_FromSize_t(hashbits->n_tags());
+}
+
+static
+PyObject *
+hashbits_count(khmer_KHashbits_Object * me, PyObject * args)
+{
+Hashbits * hashbits = me->hashbits;
+
+const char * kmer;
+
+if (!PyArg_ParseTuple(args, "s", &kmer)) {
+    return NULL;
+}
+
+if (strlen(kmer) != hashbits->ksize()) {
+    PyErr_SetString(PyExc_ValueError,
+                    "k-mer length must equal the presence table k-mer size");
+    return NULL;
+}
+
+hashbits->count(kmer);
+
+return PyLong_FromLong(1);
+}
+
+static
+PyObject *
+hashbits_consume(khmer_KHashbits_Object * me, PyObject * args)
+{
+Hashbits * hashbits = me->hashbits;
+
+const char * long_str;
+
+if (!PyArg_ParseTuple(args, "s", &long_str)) {
+    return NULL;
+}
+
+if (strlen(long_str) < hashbits->ksize()) {
+    PyErr_SetString(PyExc_ValueError,
+                    "string length must >= the hashbits k-mer size");
+    return NULL;
+}
+
+unsigned int n_consumed;
+n_consumed = hashbits->consume_string(long_str);
+
+return PyLong_FromLong(n_consumed);
+}
+
+static
+PyObject *
+hashbits_print_stop_tags(khmer_KHashbits_Object * me, PyObject * args)
+{
+Hashbits * hashbits = me->hashbits;
+
+const char * filename = NULL;
+
+if (!PyArg_ParseTuple(args, "s", &filename)) {
+    return NULL;
+}
+
+hashbits->print_stop_tags(filename);
+
+Py_RETURN_NONE;
+}
+
+static
+PyObject *
+hashbits_print_tagset(khmer_KHashbits_Object * me, PyObject * args)
+{
+Hashbits * hashbits = me->hashbits;
+
+const char * filename = NULL;
+
+if (!PyArg_ParseTuple(args, "s", &filename)) {
+    return NULL;
+}
+
+hashbits->print_tagset(filename);
+
+Py_RETURN_NONE;
+}
+
+static
+PyObject *
+hashbits_load_stop_tags(khmer_KHashbits_Object * me, PyObject * args)
+{
+Hashbits * hashbits = me->hashbits;
+
+const char * filename = NULL;
+PyObject * clear_tags_o = NULL;
+
+if (!PyArg_ParseTuple(args, "s|O", &filename, &clear_tags_o)) {
+    return NULL;
+}
+
+bool clear_tags = true;
+if (clear_tags_o && !PyObject_IsTrue(clear_tags_o)) {
+    clear_tags = false;
+}
+
+
+try {
+    hashbits->load_stop_tags(filename, clear_tags);
+} catch (khmer_file_exception &e) {
+    PyErr_SetString(PyExc_IOError, e.what());
+    return NULL;
+}
+
+Py_RETURN_NONE;
+}
+
+
+static
+PyObject *
+hashbits_save_stop_tags(khmer_KHashbits_Object * me, PyObject * args)
+{
+Hashbits * hashbits = me->hashbits;
+
+const char * filename = NULL;
+
+if (!PyArg_ParseTuple(args, "s", &filename)) {
+    return NULL;
+}
+
+hashbits->save_stop_tags(filename);
+
+Py_RETURN_NONE;
+}
+
+static
+PyObject *
+hashbits_traverse_from_tags(khmer_KHashbits_Object * me, PyObject * args)
+{
+Hashbits * hashbits = me->hashbits;
+
+khmer_KCountingHash_Object * counting_o = NULL;
+unsigned int distance, threshold, frequency;
+
+if (!PyArg_ParseTuple(args, "O!III", &khmer_KCountingHash_Type, &counting_o,
+                      &distance, &threshold, &frequency)) {
+    return NULL;
+}
+
+hashbits->traverse_from_tags(distance, threshold, frequency,
+                             * counting_o->counting);
+
+Py_RETURN_NONE;
+}
+
+static
+PyObject *
+hashbits_repartition_largest_partition(khmer_KHashbits_Object * me,
+                                   PyObject * args)
+{
+Hashbits * hashbits = me->hashbits;
+
+khmer_KCountingHash_Object * counting_o = NULL;
+PyObject * subset_o = NULL;
+unsigned int distance, threshold, frequency;
+
+if (!PyArg_ParseTuple(args, "OO!III", &subset_o, &khmer_KCountingHash_Type,
+                      &counting_o, &distance, &threshold, &frequency)) {
+    return NULL;
+}
+
+SubsetPartition * subset_p;
+if (subset_o != Py_None) {
+    subset_p = (SubsetPartition *) PyCObject_AsVoidPtr(subset_o);
+} else {
+    subset_p = hashbits->partition;
+}
+
+CountingHash * counting = counting_o->counting;
+
+unsigned long next_largest = subset_p->repartition_largest_partition(distance,
+                             threshold, frequency, *counting);
+
+return PyLong_FromLong(next_largest);
+}
+
+static
+PyObject *
+hashbits_get(khmer_KHashbits_Object * me, PyObject * args)
+{
+Hashbits * hashbits = me->hashbits;
+
+PyObject * arg;
+
+if (!PyArg_ParseTuple(args, "O", &arg)) {
+    return NULL;
+}
+
+unsigned long count = 0;
+
+if (PyInt_Check(arg)) {
+    long pos = PyInt_AsLong(arg);
+    count = hashbits->get_count((unsigned int) pos);
+} else if (PyBytes_Check(arg)) {
+    std::string s = PyBytes_AsString(arg);
+
+    if (strlen(s.c_str()) < hashbits->ksize()) {
         PyErr_SetString(PyExc_ValueError,
-                        "k-mer length must equal the presence table k-mer size");
+                        "string length must equal the presence table k-mer size");
         return NULL;
     }
 
-    hashbits->count(kmer);
-
-    return PyLong_FromLong(1);
+    count = hashbits->get_count(s.c_str());
+} else {
+    PyErr_SetString(PyExc_ValueError, "must pass in an int or string");
+    return NULL;
 }
 
-static PyObject * hashbits_consume(PyObject * self, PyObject * args)
-{
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
-    Hashbits * hashbits = me->hashbits;
-
-    const char * long_str;
-
-    if (!PyArg_ParseTuple(args, "s", &long_str)) {
-        return NULL;
-    }
-
-    if (strlen(long_str) < hashbits->ksize()) {
-        PyErr_SetString(PyExc_ValueError,
-                        "string length must >= the hashbits k-mer size");
-        return NULL;
-    }
-
-    unsigned int n_consumed;
-    n_consumed = hashbits->consume_string(long_str);
-
-    return PyLong_FromLong(n_consumed);
+return PyLong_FromLong(count);
 }
 
-static PyObject * hashbits_print_stop_tags(PyObject * self, PyObject * args)
+static
+PyObject *
+hashbits_calc_connected_graph_size(khmer_KHashbits_Object * me, PyObject * args)
 {
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
-    Hashbits * hashbits = me->hashbits;
+Hashbits * hashbits = me->hashbits;
 
-    const char * filename = NULL;
-
-    if (!PyArg_ParseTuple(args, "s", &filename)) {
-        return NULL;
-    }
-
-    hashbits->print_stop_tags(filename);
-
-    Py_RETURN_NONE;
+const char * _kmer;
+unsigned int max_size = 0;
+PyObject * break_on_circum_o = NULL;
+if (!PyArg_ParseTuple(args, "s|IO", &_kmer, &max_size, &break_on_circum_o)) {
+    return NULL;
 }
 
-static PyObject * hashbits_print_tagset(PyObject * self, PyObject * args)
-{
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
-    Hashbits * hashbits = me->hashbits;
-
-    const char * filename = NULL;
-
-    if (!PyArg_ParseTuple(args, "s", &filename)) {
-        return NULL;
-    }
-
-    hashbits->print_tagset(filename);
-
-    Py_RETURN_NONE;
+bool break_on_circum = false;
+if (break_on_circum_o && PyObject_IsTrue(break_on_circum_o)) {
+    break_on_circum = true;
 }
 
-static PyObject * hashbits_load_stop_tags(PyObject * self, PyObject * args)
-{
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
-    Hashbits * hashbits = me->hashbits;
+unsigned long long size = 0;
 
-    const char * filename = NULL;
-    PyObject * clear_tags_o = NULL;
+Py_BEGIN_ALLOW_THREADS
+SeenSet keeper;
+hashbits->calc_connected_graph_size(_kmer, size, keeper, max_size,
+                                    break_on_circum);
+Py_END_ALLOW_THREADS
 
-    if (!PyArg_ParseTuple(args, "s|O", &filename, &clear_tags_o)) {
-        return NULL;
-    }
-
-    bool clear_tags = true;
-    if (clear_tags_o && !PyObject_IsTrue(clear_tags_o)) {
-        clear_tags = false;
-    }
-
-
-    try {
-        hashbits->load_stop_tags(filename, clear_tags);
-    } catch (khmer_file_exception &e) {
-        PyErr_SetString(PyExc_IOError, e.what());
-        return NULL;
-    }
-
-    Py_RETURN_NONE;
+return PyLong_FromUnsignedLongLong(size);
 }
 
-
-static PyObject * hashbits_save_stop_tags(PyObject * self, PyObject * args)
+static
+PyObject *
+hashbits_kmer_degree(khmer_KHashbits_Object * me, PyObject * args)
 {
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
-    Hashbits * hashbits = me->hashbits;
+Hashbits * hashbits = me->hashbits;
 
-    const char * filename = NULL;
+const char * kmer_s = NULL;
 
-    if (!PyArg_ParseTuple(args, "s", &filename)) {
-        return NULL;
-    }
-
-    hashbits->save_stop_tags(filename);
-
-    Py_RETURN_NONE;
+if (!PyArg_ParseTuple(args, "s", &kmer_s)) {
+    return NULL;
 }
 
-static PyObject * hashbits_traverse_from_tags(PyObject * self, PyObject * args)
-{
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
-    Hashbits * hashbits = me->hashbits;
-
-    khmer_KCountingHash_Object * counting_o = NULL;
-    unsigned int distance, threshold, frequency;
-
-    if (!PyArg_ParseTuple(args, "O!III", &khmer_KCountingHash_Type, &counting_o,
-                          &distance, &threshold, &frequency)) {
-        return NULL;
-    }
-
-    hashbits->traverse_from_tags(distance, threshold, frequency,
-                                 * counting_o->counting);
-
-    Py_RETURN_NONE;
+return PyLong_FromLong(hashbits->kmer_degree(kmer_s));
 }
 
-static PyObject * hashbits_repartition_largest_partition(PyObject * self,
-        PyObject * args)
+static
+PyObject *
+hashbits_trim_on_stoptags(khmer_KHashbits_Object * me, PyObject * args)
 {
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
-    Hashbits * hashbits = me->hashbits;
+Hashbits * hashbits = me->hashbits;
 
-    khmer_KCountingHash_Object * counting_o = NULL;
-    PyObject * subset_o = NULL;
-    unsigned int distance, threshold, frequency;
+const char * seq = NULL;
 
-    if (!PyArg_ParseTuple(args, "OO!III", &subset_o, &khmer_KCountingHash_Type,
-                          &counting_o, &distance, &threshold, &frequency)) {
-        return NULL;
-    }
-
-    SubsetPartition * subset_p;
-    if (subset_o != Py_None) {
-        subset_p = (SubsetPartition *) PyCObject_AsVoidPtr(subset_o);
-    } else {
-        subset_p = hashbits->partition;
-    }
-
-    CountingHash * counting = counting_o->counting;
-
-    unsigned long next_largest = subset_p->repartition_largest_partition(distance,
-                                 threshold, frequency, *counting);
-
-    return PyLong_FromLong(next_largest);
+if (!PyArg_ParseTuple(args, "s", &seq)) {
+    return NULL;
 }
 
-static PyObject * hashbits_get(PyObject * self, PyObject * args)
-{
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
-    Hashbits * hashbits = me->hashbits;
+size_t trim_at;
+Py_BEGIN_ALLOW_THREADS
 
-    PyObject * arg;
+trim_at = hashbits->trim_on_stoptags(seq);
 
-    if (!PyArg_ParseTuple(args, "O", &arg)) {
-        return NULL;
-    }
+Py_END_ALLOW_THREADS;
 
-    unsigned long count = 0;
+PyObject * trim_seq = PyBytes_FromStringAndSize(seq, trim_at);
+if (trim_seq == NULL) {
+    return NULL;
+}
+PyObject * ret = Py_BuildValue("Ok", trim_seq, (unsigned long) trim_at);
+Py_DECREF(trim_seq);
 
-    if (PyInt_Check(arg)) {
-        long pos = PyInt_AsLong(arg);
-        count = hashbits->get_count((unsigned int) pos);
-    } else if (PyBytes_Check(arg)) {
-        std::string s = PyBytes_AsString(arg);
-
-        if (strlen(s.c_str()) < hashbits->ksize()) {
-            PyErr_SetString(PyExc_ValueError,
-                            "string length must equal the presence table k-mer size");
-            return NULL;
-        }
-
-        count = hashbits->get_count(s.c_str());
-    } else {
-        PyErr_SetString(PyExc_ValueError, "must pass in an int or string");
-        return NULL;
-    }
-
-    return PyLong_FromLong(count);
+return ret;
 }
 
-static PyObject * hashbits_calc_connected_graph_size(PyObject * self,
-        PyObject * args)
+static
+PyObject *
+hashbits_identify_stoptags_by_position(khmer_KHashbits_Object * me,
+                                   PyObject * args)
 {
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
-    Hashbits * hashbits = me->hashbits;
+Hashbits * hashbits = me->hashbits;
 
-    const char * _kmer;
-    unsigned int max_size = 0;
-    PyObject * break_on_circum_o = NULL;
-    if (!PyArg_ParseTuple(args, "s|IO", &_kmer, &max_size, &break_on_circum_o)) {
-        return NULL;
-    }
+const char * seq = NULL;
 
-    bool break_on_circum = false;
-    if (break_on_circum_o && PyObject_IsTrue(break_on_circum_o)) {
-        break_on_circum = true;
-    }
+if (!PyArg_ParseTuple(args, "s", &seq)) {
+    return NULL;
+}
 
-    unsigned long long size = 0;
+std::vector<unsigned int> posns;
+Py_BEGIN_ALLOW_THREADS
 
+hashbits->identify_stop_tags_by_position(seq, posns);
+
+Py_END_ALLOW_THREADS;
+
+PyObject * x = PyList_New(posns.size());
+
+for (unsigned int i = 0; i < posns.size(); i++) {
+    PyList_SET_ITEM(x, i, Py_BuildValue("I", posns[i]));
+}
+
+return x;
+}
+
+static
+PyObject *
+hashbits_do_subset_partition(khmer_KHashbits_Object * me, PyObject * args)
+{
+Hashbits * hashbits = me->hashbits;
+
+HashIntoType start_kmer = 0, end_kmer = 0;
+PyObject * break_on_stop_tags_o = NULL;
+PyObject * stop_big_traversals_o = NULL;
+
+if (!PyArg_ParseTuple(args, "|KKOO", &start_kmer, &end_kmer,
+                      &break_on_stop_tags_o,
+                      &stop_big_traversals_o)) {
+    return NULL;
+}
+
+bool break_on_stop_tags = false;
+if (break_on_stop_tags_o && PyObject_IsTrue(break_on_stop_tags_o)) {
+    break_on_stop_tags = true;
+}
+bool stop_big_traversals = false;
+if (stop_big_traversals_o && PyObject_IsTrue(stop_big_traversals_o)) {
+    stop_big_traversals = true;
+}
+
+SubsetPartition * subset_p = NULL;
+try {
     Py_BEGIN_ALLOW_THREADS
-    SeenSet keeper;
-    hashbits->calc_connected_graph_size(_kmer, size, keeper, max_size,
-                                        break_on_circum);
+    subset_p = new SubsetPartition(hashbits);
+    subset_p->do_partition(start_kmer, end_kmer, break_on_stop_tags,
+                           stop_big_traversals);
     Py_END_ALLOW_THREADS
-
-    return PyLong_FromUnsignedLongLong(size);
+} catch (_khmer_signal &e) {
+    return NULL;
+} catch (std::bad_alloc &e) {
+    return PyErr_NoMemory();
 }
 
-static PyObject * hashbits_kmer_degree(PyObject * self, PyObject * args)
-{
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
-    Hashbits * hashbits = me->hashbits;
-
-    const char * kmer_s = NULL;
-
-    if (!PyArg_ParseTuple(args, "s", &kmer_s)) {
-        return NULL;
-    }
-
-    return PyLong_FromLong(hashbits->kmer_degree(kmer_s));
+return PyCObject_FromVoidPtr(subset_p, free_subset_partition_info);
 }
 
-static PyObject * hashbits_trim_on_stoptags(PyObject * self, PyObject * args)
+static
+PyObject *
+hashbits_join_partitions_by_path(khmer_KHashbits_Object * me, PyObject * args)
 {
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
-    Hashbits * hashbits = me->hashbits;
+Hashbits * hashbits = me->hashbits;
 
-    const char * seq = NULL;
-
-    if (!PyArg_ParseTuple(args, "s", &seq)) {
-        return NULL;
-    }
-
-    size_t trim_at;
-    Py_BEGIN_ALLOW_THREADS
-
-    trim_at = hashbits->trim_on_stoptags(seq);
-
-    Py_END_ALLOW_THREADS;
-
-    PyObject * trim_seq = PyBytes_FromStringAndSize(seq, trim_at);
-    if (trim_seq == NULL) {
-        return NULL;
-    }
-    PyObject * ret = Py_BuildValue("Ok", trim_seq, (unsigned long) trim_at);
-    Py_DECREF(trim_seq);
-
-    return ret;
+const char * sequence = NULL;
+if (!PyArg_ParseTuple(args, "s", &sequence)) {
+    return NULL;
 }
 
-static PyObject * hashbits_identify_stoptags_by_position(PyObject * self,
-        PyObject * args)
-{
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
-    Hashbits * hashbits = me->hashbits;
+hashbits->partition->join_partitions_by_path(sequence);
 
-    const char * seq = NULL;
-
-    if (!PyArg_ParseTuple(args, "s", &seq)) {
-        return NULL;
-    }
-
-    std::vector<unsigned int> posns;
-    Py_BEGIN_ALLOW_THREADS
-
-    hashbits->identify_stop_tags_by_position(seq, posns);
-
-    Py_END_ALLOW_THREADS;
-
-    PyObject * x = PyList_New(posns.size());
-
-    for (unsigned int i = 0; i < posns.size(); i++) {
-        PyList_SET_ITEM(x, i, Py_BuildValue("I", posns[i]));
-    }
-
-    return x;
+Py_RETURN_NONE;
 }
 
-static PyObject * hashbits_do_subset_partition(PyObject * self,
-        PyObject * args)
+static
+PyObject *
+hashbits_merge_subset(khmer_KHashbits_Object * me, PyObject * args)
 {
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
-    Hashbits * hashbits = me->hashbits;
+Hashbits * hashbits = me->hashbits;
 
-    HashIntoType start_kmer = 0, end_kmer = 0;
-    PyObject * break_on_stop_tags_o = NULL;
-    PyObject * stop_big_traversals_o = NULL;
-
-    if (!PyArg_ParseTuple(args, "|KKOO", &start_kmer, &end_kmer,
-                          &break_on_stop_tags_o,
-                          &stop_big_traversals_o)) {
-        return NULL;
-    }
-
-    bool break_on_stop_tags = false;
-    if (break_on_stop_tags_o && PyObject_IsTrue(break_on_stop_tags_o)) {
-        break_on_stop_tags = true;
-    }
-    bool stop_big_traversals = false;
-    if (stop_big_traversals_o && PyObject_IsTrue(stop_big_traversals_o)) {
-        stop_big_traversals = true;
-    }
-
-    SubsetPartition * subset_p = NULL;
-    try {
-        Py_BEGIN_ALLOW_THREADS
-        subset_p = new SubsetPartition(hashbits);
-        subset_p->do_partition(start_kmer, end_kmer, break_on_stop_tags,
-                               stop_big_traversals);
-        Py_END_ALLOW_THREADS
-    } catch (_khmer_signal &e) {
-        return NULL;
-    } catch (std::bad_alloc &e) {
-        return PyErr_NoMemory();
-    }
-
-    return PyCObject_FromVoidPtr(subset_p, free_subset_partition_info);
+PyObject * subset_obj;
+if (!PyArg_ParseTuple(args, "O", &subset_obj)) {
+    return NULL;
 }
 
-static PyObject * hashbits_join_partitions_by_path(PyObject * self,
-        PyObject *args)
-{
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
-    Hashbits * hashbits = me->hashbits;
-
-    const char * sequence = NULL;
-    if (!PyArg_ParseTuple(args, "s", &sequence)) {
-        return NULL;
-    }
-
-    hashbits->partition->join_partitions_by_path(sequence);
-
-    Py_RETURN_NONE;
+if (!PyCObject_Check(subset_obj)) {
+    PyErr_SetString( PyExc_ValueError, "invalid subset");
+    return NULL;
 }
 
-static PyObject * hashbits_merge_subset(PyObject * self, PyObject *args)
-{
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
-    Hashbits * hashbits = me->hashbits;
+SubsetPartition * subset_p;
+subset_p = (SubsetPartition *) PyCObject_AsVoidPtr(subset_obj);
 
-    PyObject * subset_obj;
-    if (!PyArg_ParseTuple(args, "O", &subset_obj)) {
-        return NULL;
-    }
+hashbits->partition->merge(subset_p);
 
-    if (!PyCObject_Check(subset_obj)) {
-        PyErr_SetString( PyExc_ValueError, "invalid subset");
-        return NULL;
-    }
-
-    SubsetPartition * subset_p;
-    subset_p = (SubsetPartition *) PyCObject_AsVoidPtr(subset_obj);
-
-    hashbits->partition->merge(subset_p);
-
-    Py_RETURN_NONE;
+Py_RETURN_NONE;
 }
 
-static PyObject * hashbits_merge_from_disk(PyObject * self, PyObject *args)
+static
+PyObject *
+hashbits_merge_from_disk(khmer_KHashbits_Object * me, PyObject * args)
 {
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
-    Hashbits * hashbits = me->hashbits;
+Hashbits * hashbits = me->hashbits;
 
-    const char * filename = NULL;
-    if (!PyArg_ParseTuple(args, "s", &filename)) {
-        return NULL;
-    }
-
-    try {
-        hashbits->partition->merge_from_disk(filename);
-    } catch (khmer_file_exception &e) {
-        PyErr_SetString(PyExc_IOError, e.what());
-        return NULL;
-    }
-
-    Py_RETURN_NONE;
+const char * filename = NULL;
+if (!PyArg_ParseTuple(args, "s", &filename)) {
+    return NULL;
 }
 
-static PyObject * hashbits_consume_fasta(PyObject * self, PyObject * args)
-{
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
-    Hashbits * hashbits = me->hashbits;
-
-    const char * filename;
-
-    if (!PyArg_ParseTuple(args, "s", &filename)) {
-        return NULL;
-    }
-
-    // call the C++ function, and trap signals => Python
-
-    unsigned long long n_consumed = 0;
-    unsigned int total_reads = 0;
-
-    try {
-        hashbits->consume_fasta(filename, total_reads, n_consumed);
-    } catch (_khmer_signal &e) {
-        PyErr_SetString(PyExc_IOError, e.get_message().c_str());
-        return NULL;
-    } catch (khmer_file_exception &e) {
-        PyErr_SetString(PyExc_IOError, e.what());
-        return NULL;
-    }
-
-    return Py_BuildValue("IK", total_reads, n_consumed);
+try {
+    hashbits->partition->merge_from_disk(filename);
+} catch (khmer_file_exception &e) {
+    PyErr_SetString(PyExc_IOError, e.what());
+    return NULL;
 }
 
-static PyObject * hashbits_consume_fasta_with_reads_parser(
-    PyObject * self, PyObject * args
-)
-{
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
-    Hashbits * hashbits = me->hashbits;
-
-    PyObject * rparser_obj = NULL;
-
-    if (!PyArg_ParseTuple(
-                args, "O", &rparser_obj)) {
-        return NULL;
-    }
-
-    read_parsers:: IParser * rparser =
-        _PyObject_to_khmer_ReadParser( rparser_obj );
-
-    // call the C++ function, and trap signals => Python
-    unsigned long long  n_consumed  = 0;
-    unsigned int          total_reads = 0;
-    char const * exc = NULL;
-    Py_BEGIN_ALLOW_THREADS
-    try {
-        hashbits->consume_fasta(rparser, total_reads, n_consumed);
-    } catch (_khmer_signal &e) {
-        exc = e.get_message().c_str();
-    }
-
-    Py_END_ALLOW_THREADS
-    if (exc != NULL) {
-        PyErr_SetString(PyExc_IOError, exc);
-        return NULL;
-    }
-
-    return Py_BuildValue("IK", total_reads, n_consumed);
+Py_RETURN_NONE;
 }
 
-static PyObject * hashbits_consume_fasta_and_traverse(PyObject * self,
-        PyObject * args)
+static
+PyObject *
+hashbits_consume_fasta(khmer_KHashbits_Object * me, PyObject * args)
 {
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
-    Hashbits * hashbits = me->hashbits;
+Hashbits * hashbits = me->hashbits;
 
-    const char * filename;
-    unsigned int radius, big_threshold, transfer_threshold;
-    khmer_KCountingHash_Object * counting_o = NULL;
+const char * filename;
 
-    if (!PyArg_ParseTuple(args, "sIIIO!", &filename,
-                          &radius, &big_threshold, &transfer_threshold,
-                          &khmer_KCountingHash_Type, &counting_o)) {
-        return NULL;
-    }
+if (!PyArg_ParseTuple(args, "s", &filename)) {
+    return NULL;
+}
 
-    CountingHash * counting = counting_o->counting;
+// call the C++ function, and trap signals => Python
 
-    hashbits->consume_fasta_and_traverse(filename, radius, big_threshold,
-                                         transfer_threshold, *counting);
+unsigned long long n_consumed = 0;
+unsigned int total_reads = 0;
+
+try {
+    hashbits->consume_fasta(filename, total_reads, n_consumed);
+} catch (_khmer_signal &e) {
+    PyErr_SetString(PyExc_IOError, e.get_message().c_str());
+    return NULL;
+} catch (khmer_file_exception &e) {
+    PyErr_SetString(PyExc_IOError, e.what());
+    return NULL;
+}
+
+return Py_BuildValue("IK", total_reads, n_consumed);
+}
+
+static
+PyObject *
+hashbits_consume_fasta_with_reads_parser(khmer_KHashbits_Object * me,
+    PyObject * args)
+{
+Hashbits * hashbits = me->hashbits;
+
+PyObject * rparser_obj = NULL;
+
+if (!PyArg_ParseTuple(
+            args, "O", &rparser_obj)) {
+    return NULL;
+}
+
+read_parsers:: IParser * rparser =
+    _PyObject_to_khmer_ReadParser( rparser_obj );
+
+// call the C++ function, and trap signals => Python
+unsigned long long  n_consumed  = 0;
+unsigned int          total_reads = 0;
+char const * exc = NULL;
+Py_BEGIN_ALLOW_THREADS
+try {
+    hashbits->consume_fasta(rparser, total_reads, n_consumed);
+} catch (_khmer_signal &e) {
+    exc = e.get_message().c_str();
+}
+
+Py_END_ALLOW_THREADS
+if (exc != NULL) {
+    PyErr_SetString(PyExc_IOError, exc);
+    return NULL;
+}
+
+return Py_BuildValue("IK", total_reads, n_consumed);
+}
+
+static
+PyObject *
+hashbits_consume_fasta_and_traverse(khmer_KHashbits_Object * me,
+                                PyObject * args)
+{
+Hashbits * hashbits = me->hashbits;
+
+const char * filename;
+unsigned int radius, big_threshold, transfer_threshold;
+khmer_KCountingHash_Object * counting_o = NULL;
+
+if (!PyArg_ParseTuple(args, "sIIIO!", &filename,
+                      &radius, &big_threshold, &transfer_threshold,
+                      &khmer_KCountingHash_Type, &counting_o)) {
+    return NULL;
+}
+
+CountingHash * counting = counting_o->counting;
+
+hashbits->consume_fasta_and_traverse(filename, radius, big_threshold,
+                                     transfer_threshold, *counting);
 
 
-    Py_RETURN_NONE;
+Py_RETURN_NONE;
 }
 
 void sig(unsigned int total_reads, unsigned int n_consumed)
 {
-    std::cout << total_reads << " " << n_consumed << std::endl;
+std::cout << total_reads << " " << n_consumed << std::endl;
 }
 
-static PyObject * hashbits_consume_fasta_and_tag(PyObject * self,
-        PyObject * args)
+static
+PyObject *
+hashbits_consume_fasta_and_tag(khmer_KHashbits_Object * me, PyObject * args)
 {
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
     Hashbits * hashbits = me->hashbits;
 
     const char * filename;
@@ -2444,11 +2466,11 @@ static PyObject * hashbits_consume_fasta_and_tag(PyObject * self,
     return Py_BuildValue("IK", total_reads, n_consumed);
 }
 
-static PyObject * hashbits_consume_fasta_and_tag_with_reads_parser(
-    PyObject * self, PyObject * args
-)
+static
+PyObject *
+hashbits_consume_fasta_and_tag_with_reads_parser(khmer_KHashbits_Object * me,
+        PyObject * args)
 {
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
     Hashbits * hashbits = me->hashbits;
 
     python::khmer_ReadParser_Object * rparser_obj = NULL;
@@ -2483,10 +2505,11 @@ static PyObject * hashbits_consume_fasta_and_tag_with_reads_parser(
     return Py_BuildValue("IK", total_reads, n_consumed);
 }
 
-static PyObject * hashbits_consume_fasta_and_tag_with_stoptags(PyObject * self,
+static
+PyObject *
+hashbits_consume_fasta_and_tag_with_stoptags(khmer_KHashbits_Object * me,
         PyObject * args)
 {
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
     Hashbits * hashbits = me->hashbits;
 
     const char * filename;
@@ -2514,10 +2537,10 @@ static PyObject * hashbits_consume_fasta_and_tag_with_stoptags(PyObject * self,
     return Py_BuildValue("IK", total_reads, n_consumed);
 }
 
-static PyObject * hashbits_consume_partitioned_fasta(PyObject * self,
-        PyObject * args)
+static
+PyObject *
+hashbits_consume_partitioned_fasta(khmer_KHashbits_Object * me, PyObject * args)
 {
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
     Hashbits * hashbits = me->hashbits;
 
     const char * filename;
@@ -2544,9 +2567,10 @@ static PyObject * hashbits_consume_partitioned_fasta(PyObject * self,
     return Py_BuildValue("IK", total_reads, n_consumed);
 }
 
-static PyObject * hashbits_find_all_tags(PyObject * self, PyObject *args)
+static
+PyObject *
+hashbits_find_all_tags(khmer_KHashbits_Object * me, PyObject * args)
 {
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
     Hashbits * hashbits = me->hashbits;
 
     const char * kmer_s = NULL;
@@ -2582,9 +2606,10 @@ static PyObject * hashbits_find_all_tags(PyObject * self, PyObject *args)
     return PyCObject_FromVoidPtr(ppi, free_pre_partition_info);
 }
 
-static PyObject * hashbits_assign_partition_id(PyObject * self, PyObject *args)
+static
+PyObject *
+hashbits_assign_partition_id(khmer_KHashbits_Object * me, PyObject * args)
 {
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
     Hashbits * hashbits = me->hashbits;
 
     PyObject * ppi_obj;
@@ -2607,9 +2632,10 @@ static PyObject * hashbits_assign_partition_id(PyObject * self, PyObject *args)
     return PyLong_FromLong(p);
 }
 
-static PyObject * hashbits_add_tag(PyObject * self, PyObject *args)
+static
+PyObject *
+hashbits_add_tag(khmer_KHashbits_Object * me, PyObject * args)
 {
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
     Hashbits * hashbits = me->hashbits;
 
     const char * kmer_s = NULL;
@@ -2623,9 +2649,10 @@ static PyObject * hashbits_add_tag(PyObject * self, PyObject *args)
     Py_RETURN_NONE;
 }
 
-static PyObject * hashbits_add_stop_tag(PyObject * self, PyObject *args)
+static
+PyObject *
+hashbits_add_stop_tag(khmer_KHashbits_Object * me, PyObject * args)
 {
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
     Hashbits * hashbits = me->hashbits;
 
     const char * kmer_s = NULL;
@@ -2639,9 +2666,10 @@ static PyObject * hashbits_add_stop_tag(PyObject * self, PyObject *args)
     Py_RETURN_NONE;
 }
 
-static PyObject * hashbits_get_stop_tags(PyObject * self, PyObject * args)
+static
+PyObject *
+hashbits_get_stop_tags(khmer_KHashbits_Object * me, PyObject * args)
 {
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
     Hashbits * hashbits = me->hashbits;
 
     if (!PyArg_ParseTuple(args, "")) {
@@ -2662,9 +2690,10 @@ static PyObject * hashbits_get_stop_tags(PyObject * self, PyObject * args)
     return x;
 }
 
-static PyObject * hashbits_get_tagset(PyObject * self, PyObject * args)
+static
+PyObject *
+hashbits_get_tagset(khmer_KHashbits_Object * me, PyObject * args)
 {
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
     Hashbits * hashbits = me->hashbits;
 
     if (!PyArg_ParseTuple(args, "")) {
@@ -2685,9 +2714,10 @@ static PyObject * hashbits_get_tagset(PyObject * self, PyObject * args)
     return x;
 }
 
-static PyObject * hashbits_output_partitions(PyObject * self, PyObject * args)
+static
+PyObject *
+hashbits_output_partitions(khmer_KHashbits_Object * me, PyObject * args)
 {
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
     Hashbits * hashbits = me->hashbits;
 
     const char * filename = NULL;
@@ -2722,9 +2752,10 @@ static PyObject * hashbits_output_partitions(PyObject * self, PyObject * args)
     return PyLong_FromLong(n_partitions);
 }
 
-static PyObject * hashbits_find_unpart(PyObject * self, PyObject * args)
+static
+PyObject *
+hashbits_find_unpart(khmer_KHashbits_Object * me, PyObject * args)
 {
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
     Hashbits * hashbits = me->hashbits;
 
     const char * filename = NULL;
@@ -2754,9 +2785,10 @@ static PyObject * hashbits_find_unpart(PyObject * self, PyObject * args)
     // return Py_None;
 }
 
-static PyObject * hashbits_filter_if_present(PyObject * self, PyObject * args)
+static
+PyObject *
+hashbits_filter_if_present(khmer_KHashbits_Object * me, PyObject * args)
 {
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
     Hashbits * hashbits = me->hashbits;
 
     const char * filename = NULL;
@@ -2775,9 +2807,10 @@ static PyObject * hashbits_filter_if_present(PyObject * self, PyObject * args)
     Py_RETURN_NONE;
 }
 
-static PyObject * hashbits_save_partitionmap(PyObject * self, PyObject * args)
+static
+PyObject *
+hashbits_save_partitionmap(khmer_KHashbits_Object * me, PyObject * args)
 {
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
     Hashbits * hashbits = me->hashbits;
 
     const char * filename = NULL;
@@ -2791,9 +2824,10 @@ static PyObject * hashbits_save_partitionmap(PyObject * self, PyObject * args)
     Py_RETURN_NONE;
 }
 
-static PyObject * hashbits_load_partitionmap(PyObject * self, PyObject * args)
+static
+PyObject *
+hashbits_load_partitionmap(khmer_KHashbits_Object * me, PyObject * args)
 {
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
     Hashbits * hashbits = me->hashbits;
 
     const char * filename = NULL;
@@ -2807,10 +2841,10 @@ static PyObject * hashbits_load_partitionmap(PyObject * self, PyObject * args)
     Py_RETURN_NONE;
 }
 
-static PyObject * hashbits__validate_partitionmap(PyObject * self,
-        PyObject * args)
+static
+PyObject *
+hashbits__validate_partitionmap(khmer_KHashbits_Object * me, PyObject * args)
 {
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
     Hashbits * hashbits = me->hashbits;
 
     if (!PyArg_ParseTuple(args, "")) {
@@ -2822,9 +2856,10 @@ static PyObject * hashbits__validate_partitionmap(PyObject * self,
     Py_RETURN_NONE;
 }
 
-static PyObject * hashbits_count_partitions(PyObject * self, PyObject * args)
+static
+PyObject *
+hashbits_count_partitions(khmer_KHashbits_Object * me, PyObject * args)
 {
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
     Hashbits * hashbits = me->hashbits;
 
     if (!PyArg_ParseTuple(args, "")) {
@@ -2838,8 +2873,9 @@ static PyObject * hashbits_count_partitions(PyObject * self, PyObject * args)
                          (Py_ssize_t) n_unassigned);
 }
 
-static PyObject * hashbits_subset_count_partitions(PyObject * self,
-        PyObject * args)
+static
+PyObject *
+hashbits_subset_count_partitions(khmer_KHashbits_Object * me, PyObject * args)
 {
     PyObject * subset_obj = NULL;
 
@@ -2857,7 +2893,9 @@ static PyObject * hashbits_subset_count_partitions(PyObject * self,
                          (Py_ssize_t) n_unassigned);
 }
 
-static PyObject * hashbits_subset_partition_size_distribution(PyObject * self,
+static
+PyObject *
+hashbits_subset_partition_size_distribution(khmer_KHashbits_Object * me,
         PyObject * args)
 {
     PyObject * subset_obj = NULL;
@@ -2900,9 +2938,10 @@ static PyObject * hashbits_subset_partition_size_distribution(PyObject * self,
     return returnValue;
 }
 
-static PyObject * hashbits_load(PyObject * self, PyObject * args)
+static
+PyObject *
+hashbits_load(khmer_KHashbits_Object * me, PyObject * args)
 {
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
     Hashbits * hashbits = me->hashbits;
 
     const char * filename = NULL;
@@ -2921,9 +2960,10 @@ static PyObject * hashbits_load(PyObject * self, PyObject * args)
     Py_RETURN_NONE;
 }
 
-static PyObject * hashbits_save(PyObject * self, PyObject * args)
+static
+PyObject *
+hashbits_save(khmer_KHashbits_Object * me, PyObject * args)
 {
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
     Hashbits * hashbits = me->hashbits;
 
     const char * filename = NULL;
@@ -2937,9 +2977,10 @@ static PyObject * hashbits_save(PyObject * self, PyObject * args)
     Py_RETURN_NONE;
 }
 
-static PyObject * hashbits_load_tagset(PyObject * self, PyObject * args)
+static
+PyObject *
+hashbits_load_tagset(khmer_KHashbits_Object * me, PyObject * args)
 {
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
     Hashbits * hashbits = me->hashbits;
 
     const char * filename = NULL;
@@ -2964,9 +3005,10 @@ static PyObject * hashbits_load_tagset(PyObject * self, PyObject * args)
     Py_RETURN_NONE;
 }
 
-static PyObject * hashbits_save_tagset(PyObject * self, PyObject * args)
+static
+PyObject *
+hashbits_save_tagset(khmer_KHashbits_Object * me, PyObject * args)
 {
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
     Hashbits * hashbits = me->hashbits;
 
     const char * filename = NULL;
@@ -2980,8 +3022,9 @@ static PyObject * hashbits_save_tagset(PyObject * self, PyObject * args)
     Py_RETURN_NONE;
 }
 
-static PyObject * hashbits_save_subset_partitionmap(PyObject * self,
-        PyObject * args)
+static
+PyObject *
+hashbits_save_subset_partitionmap(khmer_KHashbits_Object * me, PyObject * args)
 {
     const char * filename = NULL;
     PyObject * subset_obj = NULL;
@@ -3002,10 +3045,10 @@ static PyObject * hashbits_save_subset_partitionmap(PyObject * self,
     Py_RETURN_NONE;
 }
 
-static PyObject * hashbits_load_subset_partitionmap(PyObject * self,
-        PyObject * args)
+static
+PyObject *
+hashbits_load_subset_partitionmap(khmer_KHashbits_Object * me, PyObject * args)
 {
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
     Hashbits * hashbits = me->hashbits;
 
     const char * filename = NULL;
@@ -3044,9 +3087,10 @@ static PyObject * hashbits_load_subset_partitionmap(PyObject * self,
     }
 }
 
-static PyObject * hashbits__set_tag_density(PyObject * self, PyObject * args)
+static
+PyObject *
+hashbits__set_tag_density(khmer_KHashbits_Object * me, PyObject * args)
 {
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
     Hashbits * hashbits = me->hashbits;
 
     unsigned int d;
@@ -3059,9 +3103,10 @@ static PyObject * hashbits__set_tag_density(PyObject * self, PyObject * args)
     Py_RETURN_NONE;
 }
 
-static PyObject * hashbits__get_tag_density(PyObject * self, PyObject * args)
+static
+PyObject *
+hashbits__get_tag_density(khmer_KHashbits_Object * me, PyObject * args)
 {
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
     Hashbits * hashbits = me->hashbits;
 
     if (!PyArg_ParseTuple(args, "")) {
@@ -3073,8 +3118,10 @@ static PyObject * hashbits__get_tag_density(PyObject * self, PyObject * args)
     return PyLong_FromLong(d);
 }
 
-static PyObject * hashbits__validate_subset_partitionmap(PyObject * self,
-        PyObject * args)
+static
+PyObject *
+hashbits__validate_subset_partitionmap(khmer_KHashbits_Object * me,
+                                       PyObject * args)
 {
     PyObject * subset_obj = NULL;
 
@@ -3089,9 +3136,10 @@ static PyObject * hashbits__validate_subset_partitionmap(PyObject * self,
     Py_RETURN_NONE;
 }
 
-static PyObject * hashbits_set_partition_id(PyObject * self, PyObject * args)
+static
+PyObject *
+hashbits_set_partition_id(khmer_KHashbits_Object * me, PyObject * args)
 {
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
     Hashbits * hashbits = me->hashbits;
 
     const char * kmer = NULL;
@@ -3106,9 +3154,10 @@ static PyObject * hashbits_set_partition_id(PyObject * self, PyObject * args)
     Py_RETURN_NONE;
 }
 
-static PyObject * hashbits_join_partitions(PyObject * self, PyObject * args)
+static
+PyObject *
+hashbits_join_partitions(khmer_KHashbits_Object * me, PyObject * args)
 {
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
     Hashbits * hashbits = me->hashbits;
 
     PartitionID p1 = 0, p2 = 0;
@@ -3122,9 +3171,10 @@ static PyObject * hashbits_join_partitions(PyObject * self, PyObject * args)
     return PyLong_FromLong(p1);
 }
 
-static PyObject * hashbits_get_partition_id(PyObject * self, PyObject * args)
+static
+PyObject *
+hashbits_get_partition_id(khmer_KHashbits_Object * me, PyObject * args)
 {
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
     Hashbits * hashbits = me->hashbits;
 
     const char * kmer = NULL;
@@ -3139,10 +3189,10 @@ static PyObject * hashbits_get_partition_id(PyObject * self, PyObject * args)
     return PyLong_FromLong(partition_id);
 }
 
-static PyObject * hashbits_is_single_partition(PyObject * self,
-        PyObject * args)
+static
+PyObject *
+hashbits_is_single_partition(khmer_KHashbits_Object * me, PyObject * args)
 {
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
     Hashbits * hashbits = me->hashbits;
 
     const char * seq = NULL;
@@ -3164,10 +3214,10 @@ static PyObject * hashbits_is_single_partition(PyObject * self,
     return val;
 }
 
-static PyObject * hashbits_divide_tags_into_subsets(PyObject * self,
-        PyObject * args)
+static
+PyObject *
+hashbits_divide_tags_into_subsets(khmer_KHashbits_Object * me, PyObject * args)
 {
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
     Hashbits * hashbits = me->hashbits;
 
     unsigned int subset_size = 0;
@@ -3189,10 +3239,10 @@ static PyObject * hashbits_divide_tags_into_subsets(PyObject * self,
     return x;
 }
 
-static PyObject * hashbits_count_kmers_within_radius(PyObject * self,
-        PyObject * args)
+static
+PyObject *
+hashbits_count_kmers_within_radius(khmer_KHashbits_Object * me, PyObject * args)
 {
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
     Hashbits * hashbits = me->hashbits;
 
     const char * kmer = NULL;
@@ -3217,9 +3267,10 @@ static PyObject * hashbits_count_kmers_within_radius(PyObject * self,
     return PyLong_FromUnsignedLong(n);
 }
 
-static PyObject * hashbits_get_ksize(PyObject * self, PyObject * args)
+static
+PyObject *
+hashbits_get_ksize(khmer_KHashbits_Object * me, PyObject * args)
 {
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
     Hashbits * hashbits = me->hashbits;
 
     if (!PyArg_ParseTuple(args, "")) {
@@ -3232,9 +3283,10 @@ static PyObject * hashbits_get_ksize(PyObject * self, PyObject * args)
 }
 
 
-static PyObject * hashbits_get_hashsizes(PyObject * self, PyObject * args)
+static
+PyObject *
+hashbits_get_hashsizes(khmer_KHashbits_Object * me, PyObject * args)
 {
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
     Hashbits * hashbits = me->hashbits;
 
     if (!PyArg_ParseTuple(args, "")) {
@@ -3251,10 +3303,10 @@ static PyObject * hashbits_get_hashsizes(PyObject * self, PyObject * args)
     return x;
 }
 
-static PyObject * hashbits_extract_unique_paths(PyObject * self,
-        PyObject * args)
+static
+PyObject *
+hashbits_extract_unique_paths(khmer_KHashbits_Object * me, PyObject * args)
 {
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
     Hashbits * hashbits = me->hashbits;
 
     const char * sequence = NULL;
@@ -3279,9 +3331,10 @@ static PyObject * hashbits_extract_unique_paths(PyObject * self,
     return x;
 }
 
-static PyObject * hashbits_get_median_count(PyObject * self, PyObject * args)
+static
+PyObject *
+hashbits_get_median_count(khmer_KHashbits_Object * me, PyObject * args)
 {
-    khmer_KHashbitsObject * me = (khmer_KHashbitsObject *) self;
     Hashbits * hashbits = me->hashbits;
 
     const char * long_str;
@@ -3305,71 +3358,71 @@ static PyObject * hashbits_get_median_count(PyObject * self, PyObject * args)
 }
 
 static PyMethodDef khmer_hashbits_methods[] = {
-    { "extract_unique_paths", hashbits_extract_unique_paths, METH_VARARGS, "" },
-    { "ksize", hashbits_get_ksize, METH_VARARGS, "" },
-    { "hashsizes", hashbits_get_hashsizes, METH_VARARGS, "" },
-    { "n_occupied", hashbits_n_occupied, METH_VARARGS, "Count the number of occupied bins" },
-    { "n_unique_kmers", hashbits_n_unique_kmers,  METH_VARARGS, "Count the number of unique kmers" },
-    { "count", hashbits_count, METH_VARARGS, "Count the given kmer" },
-    { "count_overlap", hashbits_count_overlap, METH_VARARGS, "Count overlap kmers in two datasets" },
-    { "consume", hashbits_consume, METH_VARARGS, "Count all k-mers in the given string" },
-    { "load_stop_tags", hashbits_load_stop_tags, METH_VARARGS, "" },
-    { "save_stop_tags", hashbits_save_stop_tags, METH_VARARGS, "" },
-    { "print_stop_tags", hashbits_print_stop_tags, METH_VARARGS, "" },
-    { "print_tagset", hashbits_print_tagset, METH_VARARGS, "" },
-    { "get", hashbits_get, METH_VARARGS, "Get the count for the given k-mer" },
-    { "calc_connected_graph_size", hashbits_calc_connected_graph_size, METH_VARARGS, "" },
-    { "kmer_degree", hashbits_kmer_degree, METH_VARARGS, "" },
-    { "trim_on_stoptags", hashbits_trim_on_stoptags, METH_VARARGS, "" },
-    { "identify_stoptags_by_position", hashbits_identify_stoptags_by_position, METH_VARARGS, "" },
-    { "do_subset_partition", hashbits_do_subset_partition, METH_VARARGS, "" },
-    { "find_all_tags", hashbits_find_all_tags, METH_VARARGS, "" },
-    { "assign_partition_id", hashbits_assign_partition_id, METH_VARARGS, "" },
-    { "output_partitions", hashbits_output_partitions, METH_VARARGS, "" },
-    { "find_unpart", hashbits_find_unpart, METH_VARARGS, "" },
-    { "filter_if_present", hashbits_filter_if_present, METH_VARARGS, "" },
-    { "add_tag", hashbits_add_tag, METH_VARARGS, "" },
-    { "add_stop_tag", hashbits_add_stop_tag, METH_VARARGS, "" },
-    { "get_stop_tags", hashbits_get_stop_tags, METH_VARARGS, "" },
-    { "get_tagset", hashbits_get_tagset, METH_VARARGS, "" },
-    { "load", hashbits_load, METH_VARARGS, "" },
-    { "save", hashbits_save, METH_VARARGS, "" },
-    { "load_tagset", hashbits_load_tagset, METH_VARARGS, "" },
-    { "save_tagset", hashbits_save_tagset, METH_VARARGS, "" },
-    { "n_tags", hashbits_n_tags, METH_VARARGS, "" },
-    { "divide_tags_into_subsets", hashbits_divide_tags_into_subsets, METH_VARARGS, "" },
-    { "load_partitionmap", hashbits_load_partitionmap, METH_VARARGS, "" },
-    { "save_partitionmap", hashbits_save_partitionmap, METH_VARARGS, "" },
-    { "_validate_partitionmap", hashbits__validate_partitionmap, METH_VARARGS, "" },
-    { "_get_tag_density", hashbits__get_tag_density, METH_VARARGS, "" },
-    { "_set_tag_density", hashbits__set_tag_density, METH_VARARGS, "" },
-    { "consume_fasta", hashbits_consume_fasta, METH_VARARGS, "Count all k-mers in a given file" },
-    { "consume_fasta_with_reads_parser", hashbits_consume_fasta_with_reads_parser, METH_VARARGS, "Count all k-mers in a given file" },
-    { "consume_fasta_and_tag", hashbits_consume_fasta_and_tag, METH_VARARGS, "Count all k-mers in a given file" },
+    { "extract_unique_paths", (PyCFunction)hashbits_extract_unique_paths, METH_VARARGS, "" },
+    { "ksize", (PyCFunction)hashbits_get_ksize, METH_VARARGS, "" },
+    { "hashsizes", (PyCFunction)hashbits_get_hashsizes, METH_VARARGS, "" },
+    { "n_occupied", (PyCFunction)hashbits_n_occupied, METH_VARARGS, "Count the number of occupied bins" },
+    { "n_unique_kmers", (PyCFunction)hashbits_n_unique_kmers,  METH_VARARGS, "Count the number of unique kmers" },
+    { "count", (PyCFunction)hashbits_count, METH_VARARGS, "Count the given kmer" },
+    { "count_overlap", (PyCFunction)hashbits_count_overlap, METH_VARARGS, "Count overlap kmers in two datasets" },
+    { "consume", (PyCFunction)hashbits_consume, METH_VARARGS, "Count all k-mers in the given string" },
+    { "load_stop_tags", (PyCFunction)hashbits_load_stop_tags, METH_VARARGS, "" },
+    { "save_stop_tags", (PyCFunction)hashbits_save_stop_tags, METH_VARARGS, "" },
+    { "print_stop_tags", (PyCFunction)hashbits_print_stop_tags, METH_VARARGS, "" },
+    { "print_tagset", (PyCFunction)hashbits_print_tagset, METH_VARARGS, "" },
+    { "get", (PyCFunction)hashbits_get, METH_VARARGS, "Get the count for the given k-mer" },
+    { "calc_connected_graph_size", (PyCFunction)hashbits_calc_connected_graph_size, METH_VARARGS, "" },
+    { "kmer_degree", (PyCFunction)hashbits_kmer_degree, METH_VARARGS, "" },
+    { "trim_on_stoptags", (PyCFunction)hashbits_trim_on_stoptags, METH_VARARGS, "" },
+    { "identify_stoptags_by_position", (PyCFunction)hashbits_identify_stoptags_by_position, METH_VARARGS, "" },
+    { "do_subset_partition", (PyCFunction)hashbits_do_subset_partition, METH_VARARGS, "" },
+    { "find_all_tags", (PyCFunction)hashbits_find_all_tags, METH_VARARGS, "" },
+    { "assign_partition_id", (PyCFunction)hashbits_assign_partition_id, METH_VARARGS, "" },
+    { "output_partitions", (PyCFunction)hashbits_output_partitions, METH_VARARGS, "" },
+    { "find_unpart", (PyCFunction)hashbits_find_unpart, METH_VARARGS, "" },
+    { "filter_if_present", (PyCFunction)hashbits_filter_if_present, METH_VARARGS, "" },
+    { "add_tag", (PyCFunction)hashbits_add_tag, METH_VARARGS, "" },
+    { "add_stop_tag", (PyCFunction)hashbits_add_stop_tag, METH_VARARGS, "" },
+    { "get_stop_tags", (PyCFunction)hashbits_get_stop_tags, METH_VARARGS, "" },
+    { "get_tagset", (PyCFunction)hashbits_get_tagset, METH_VARARGS, "" },
+    { "load", (PyCFunction)hashbits_load, METH_VARARGS, "" },
+    { "save", (PyCFunction)hashbits_save, METH_VARARGS, "" },
+    { "load_tagset", (PyCFunction)hashbits_load_tagset, METH_VARARGS, "" },
+    { "save_tagset", (PyCFunction)hashbits_save_tagset, METH_VARARGS, "" },
+    { "n_tags", (PyCFunction)hashbits_n_tags, METH_VARARGS, "" },
+    { "divide_tags_into_subsets", (PyCFunction)hashbits_divide_tags_into_subsets, METH_VARARGS, "" },
+    { "load_partitionmap", (PyCFunction)hashbits_load_partitionmap, METH_VARARGS, "" },
+    { "save_partitionmap", (PyCFunction)hashbits_save_partitionmap, METH_VARARGS, "" },
+    { "_validate_partitionmap", (PyCFunction)hashbits__validate_partitionmap, METH_VARARGS, "" },
+    { "_get_tag_density", (PyCFunction)hashbits__get_tag_density, METH_VARARGS, "" },
+    { "_set_tag_density", (PyCFunction)hashbits__set_tag_density, METH_VARARGS, "" },
+    { "consume_fasta", (PyCFunction)hashbits_consume_fasta, METH_VARARGS, "Count all k-mers in a given file" },
+    { "consume_fasta_with_reads_parser", (PyCFunction)hashbits_consume_fasta_with_reads_parser, METH_VARARGS, "Count all k-mers in a given file" },
+    { "consume_fasta_and_tag", (PyCFunction)hashbits_consume_fasta_and_tag, METH_VARARGS, "Count all k-mers in a given file" },
     {
-        "consume_fasta_and_tag_with_reads_parser", hashbits_consume_fasta_and_tag_with_reads_parser,
+        "consume_fasta_and_tag_with_reads_parser", (PyCFunction)hashbits_consume_fasta_and_tag_with_reads_parser,
         METH_VARARGS, "Count all k-mers using a given reads parser"
     },
-    { "consume_fasta_and_traverse", hashbits_consume_fasta_and_traverse, METH_VARARGS, "" },
-    { "consume_fasta_and_tag_with_stoptags", hashbits_consume_fasta_and_tag_with_stoptags, METH_VARARGS, "Count all k-mers in a given file" },
-    { "consume_partitioned_fasta", hashbits_consume_partitioned_fasta, METH_VARARGS, "Count all k-mers in a given file" },
-    { "join_partitions_by_path", hashbits_join_partitions_by_path, METH_VARARGS, "" },
-    { "merge_subset", hashbits_merge_subset, METH_VARARGS, "" },
-    { "merge_subset_from_disk", hashbits_merge_from_disk, METH_VARARGS, "" },
-    { "count_partitions", hashbits_count_partitions, METH_VARARGS, "" },
-    { "subset_count_partitions", hashbits_subset_count_partitions, METH_VARARGS, "" },
-    { "subset_partition_size_distribution", hashbits_subset_partition_size_distribution, METH_VARARGS, "" },
-    { "save_subset_partitionmap", hashbits_save_subset_partitionmap, METH_VARARGS },
-    { "load_subset_partitionmap", hashbits_load_subset_partitionmap, METH_VARARGS },
-    { "_validate_subset_partitionmap", hashbits__validate_subset_partitionmap, METH_VARARGS, "" },
-    { "set_partition_id", hashbits_set_partition_id, METH_VARARGS, "" },
-    { "join_partitions", hashbits_join_partitions, METH_VARARGS, "" },
-    { "get_partition_id", hashbits_get_partition_id, METH_VARARGS, "" },
-    { "is_single_partition", hashbits_is_single_partition, METH_VARARGS, "" },
-    { "count_kmers_within_radius", hashbits_count_kmers_within_radius, METH_VARARGS, "" },
-    { "traverse_from_tags", hashbits_traverse_from_tags, METH_VARARGS, "" },
-    { "repartition_largest_partition", hashbits_repartition_largest_partition, METH_VARARGS, "" },
-    { "get_median_count", hashbits_get_median_count, METH_VARARGS, "Get the median, average, and stddev of the k-mer counts in the string" },
+    { "consume_fasta_and_traverse", (PyCFunction)hashbits_consume_fasta_and_traverse, METH_VARARGS, "" },
+    { "consume_fasta_and_tag_with_stoptags", (PyCFunction)hashbits_consume_fasta_and_tag_with_stoptags, METH_VARARGS, "Count all k-mers in a given file" },
+    { "consume_partitioned_fasta", (PyCFunction)hashbits_consume_partitioned_fasta, METH_VARARGS, "Count all k-mers in a given file" },
+    { "join_partitions_by_path", (PyCFunction)hashbits_join_partitions_by_path, METH_VARARGS, "" },
+    { "merge_subset", (PyCFunction)hashbits_merge_subset, METH_VARARGS, "" },
+    { "merge_subset_from_disk", (PyCFunction)hashbits_merge_from_disk, METH_VARARGS, "" },
+    { "count_partitions", (PyCFunction)hashbits_count_partitions, METH_VARARGS, "" },
+    { "subset_count_partitions", (PyCFunction)hashbits_subset_count_partitions, METH_VARARGS, "" },
+    { "subset_partition_size_distribution", (PyCFunction)hashbits_subset_partition_size_distribution, METH_VARARGS, "" },
+    { "save_subset_partitionmap", (PyCFunction)hashbits_save_subset_partitionmap, METH_VARARGS },
+    { "load_subset_partitionmap", (PyCFunction)hashbits_load_subset_partitionmap, METH_VARARGS },
+    { "_validate_subset_partitionmap", (PyCFunction)hashbits__validate_subset_partitionmap, METH_VARARGS, "" },
+    { "set_partition_id", (PyCFunction)hashbits_set_partition_id, METH_VARARGS, "" },
+    { "join_partitions", (PyCFunction)hashbits_join_partitions, METH_VARARGS, "" },
+    { "get_partition_id", (PyCFunction)hashbits_get_partition_id, METH_VARARGS, "" },
+    { "is_single_partition", (PyCFunction)hashbits_is_single_partition, METH_VARARGS, "" },
+    { "count_kmers_within_radius", (PyCFunction)hashbits_count_kmers_within_radius, METH_VARARGS, "" },
+    { "traverse_from_tags", (PyCFunction)hashbits_traverse_from_tags, METH_VARARGS, "" },
+    { "repartition_largest_partition", (PyCFunction)hashbits_repartition_largest_partition, METH_VARARGS, "" },
+    { "get_median_count", (PyCFunction)hashbits_get_median_count, METH_VARARGS, "Get the median, average, and stddev of the k-mer counts in the string" },
     {NULL, NULL, 0, NULL}           /* sentinel */
 };
 
@@ -3380,8 +3433,8 @@ static PyMethodDef khmer_hashbits_methods[] = {
 static PyObject* khmer_hashbits_new(PyTypeObject * type, PyObject * args,
                                     PyObject * kwds)
 {
-    khmer_KHashbitsObject * self;
-    self = (khmer_KHashbitsObject *)type->tp_alloc(type, 0);
+    khmer_KHashbits_Object * self;
+    self = (khmer_KHashbits_Object *)type->tp_alloc(type, 0);
 
     if (self != NULL) {
         WordLength k = 0;
@@ -3420,13 +3473,13 @@ static PyObject* khmer_hashbits_new(PyTypeObject * type, PyObject * args,
 }
 
 // there are no attributes that we need at this time, so we'll just return 0
-static int khmer_hashbits_init(khmer_KHashbitsObject * self, PyObject * args,
+static int khmer_hashbits_init(khmer_KHashbits_Object * self, PyObject * args,
                                PyObject * kwds)
 {
     return 0;
 }
 
-#define is_hashbits_obj(v)  (Py_TYPE(v) == &khmer_KHashbitsType)
+#define is_hashbits_obj(v)  (Py_TYPE(v) == &khmer_KHashbits_Type)
 
 ////////////////////////////////////////////////////////////////////////////
 
@@ -3654,7 +3707,7 @@ static PyMethodDef khmer_subset_methods[] = {
 // LabelHash addition
 typedef struct {
     //PyObject_HEAD
-    khmer_KHashbitsObject khashbits;
+    khmer_KHashbits_Object khashbits;
     LabelHash * labelhash;
 } khmer_KLabelHashObject;
 
@@ -3735,7 +3788,7 @@ static PyObject * khmer_labelhash_new(PyTypeObject *type, PyObject *args,
 static int khmer_labelhash_init(khmer_KLabelHashObject * self, PyObject *args,
                                 PyObject *kwds)
 {
-    if (khmer_KHashbitsType.tp_init((PyObject *)self, args, kwds) < 0) {
+    if (khmer_KHashbits_Type.tp_init((PyObject *)self, args, kwds) < 0) {
         return -1;
     }
     //std::cout << "testing my pointer ref to hashbits: " << self->khashbits.hashbits->n_tags() << std::endl;
@@ -4194,54 +4247,6 @@ static PyTypeObject khmer_ReadAlignerType = {
     khmer_ReadAligner_new,     /* tp_new */
 };
 
-
-//
-// new_hashbits
-//
-
-static PyObject* _new_hashbits(PyObject * self, PyObject * args)
-{
-    WordLength k = 0;
-    PyListObject * sizes_list_o = NULL;
-
-    if (!PyArg_ParseTuple(args, "bO!", &k, &PyList_Type, &sizes_list_o)) {
-        return NULL;
-    }
-
-    std::vector<HashIntoType> sizes;
-    Py_ssize_t sizes_list_o_length = PyList_GET_SIZE(sizes_list_o);
-    for (Py_ssize_t i = 0; i < sizes_list_o_length; i++) {
-        PyObject * size_o = PyList_GET_ITEM(sizes_list_o, i);
-        if (PyLong_Check(size_o)) {
-            sizes.push_back((HashIntoType) PyLong_AsUnsignedLongLong(size_o));
-        } else if (PyInt_Check(size_o)) {
-            sizes.push_back((HashIntoType) PyInt_AsLong(size_o));
-        } else if (PyFloat_Check(size_o)) {
-            sizes.push_back((HashIntoType) PyFloat_AS_DOUBLE(size_o));
-        } else {
-            PyErr_SetString(PyExc_TypeError,
-                            "2nd argument must be a list of ints, longs, or floats");
-            return NULL;
-        }
-    }
-
-
-    khmer_KHashbitsObject * khashbits_obj = (khmer_KHashbitsObject *) \
-                                            PyObject_New(khmer_KHashbitsObject, &khmer_KHashbitsType);
-
-    if (khashbits_obj == NULL) {
-        return NULL;
-    }
-
-    try {
-        khashbits_obj->hashbits = new Hashbits(k, sizes);
-    } catch (std::bad_alloc &e) {
-        return PyErr_NoMemory();
-    }
-
-    return (PyObject *) khashbits_obj;
-}
-
 static PyObject * hash_collect_high_abundance_kmers(khmer_KCountingHash_Object *
         me , PyObject * args)
 {
@@ -4262,8 +4267,8 @@ static PyObject * hash_collect_high_abundance_kmers(khmer_KCountingHash_Object *
     std::vector<HashIntoType> sizes;
     sizes.push_back(1);
 
-    khmer_KHashbitsObject * khashbits_obj = (khmer_KHashbitsObject *) \
-                                            PyObject_New(khmer_KHashbitsObject, &khmer_KHashbitsType);
+    khmer_KHashbits_Object * khashbits_obj = (khmer_KHashbits_Object *) \
+            PyObject_New(khmer_KHashbits_Object, &khmer_KHashbits_Type);
     if (khashbits_obj == NULL) {
         return NULL;
     }
@@ -4293,15 +4298,12 @@ static void khmer_counting_dealloc(khmer_KCountingHash_Object * obj)
 //
 // khmer_hashbits_dealloc -- clean up a hashbits object.
 //
-static void khmer_hashbits_dealloc(PyObject* obj)
+static void khmer_hashbits_dealloc(khmer_KHashbits_Object * obj)
 {
-    khmer_KHashbitsObject * self = (khmer_KHashbitsObject *) obj;
-
-    delete self->hashbits;
-    self->hashbits = NULL;
+    delete obj->hashbits;
+    obj->hashbits = NULL;
 
     Py_TYPE(obj)->tp_free((PyObject*)obj);
-    //PyObject_Del((PyObject *) obj);
 }
 
 
@@ -4640,10 +4642,6 @@ static PyMethodDef KhmerMethods[] = {
         METH_VARARGS,       "Create an empty single-table counting hash"
     },
     {
-        "_new_hashbits",        _new_hashbits,
-        METH_VARARGS,       "Create an empty hashbits table"
-    },
-    {
         "forward_hash",     forward_hash,
         METH_VARARGS,       "",
     },
@@ -4692,14 +4690,13 @@ init_khmer(void)
 
     // implemented __new__ for Hashbits; keeping factory func around as well
     // for backwards compat with old scripts
-    khmer_KHashbitsType.tp_new = khmer_hashbits_new;
-    khmer_KHashbitsType.tp_methods = khmer_hashbits_methods;
-    if (PyType_Ready(&khmer_KHashbitsType) < 0) {
+    khmer_KHashbits_Type.tp_methods = khmer_hashbits_methods;
+    if (PyType_Ready(&khmer_KHashbits_Type) < 0) {
         return;
     }
     // add LabelHash
 
-    khmer_KLabelHashType.tp_base = &khmer_KHashbitsType;
+    khmer_KLabelHashType.tp_base = &khmer_KHashbits_Type;
     khmer_KLabelHashType.tp_new = khmer_labelhash_new;
     if (PyType_Ready(&khmer_KLabelHashType) < 0) {
         return;
@@ -4748,8 +4745,10 @@ init_khmer(void)
         return;
     }
 
-    Py_INCREF(&khmer_KHashbitsType);
-    PyModule_AddObject(m, "_Hashbits", (PyObject *)&khmer_KHashbitsType);
+    Py_INCREF(&khmer_KHashbits_Type);
+    if (PyModule_AddObject(m, "_Hashbits", (PyObject *)&khmer_KHashbits_Type) < 0) {
+        return;
+    }
 
     Py_INCREF(&khmer_KLabelHashType);
     PyModule_AddObject(m, "_LabelHash", (PyObject *)&khmer_KLabelHashType);

--- a/khmer/_khmermodule.cc
+++ b/khmer/_khmermodule.cc
@@ -461,7 +461,7 @@ static PyTypeObject khmer_ReadPairIterator_Type = {
 
 static
 PyObject *
-ReadParser_iter_reads( PyObject * self, PyObject * args )
+ReadParser_iter_reads(PyObject * self, PyObject * args )
 {
     return PyObject_SelfIter( self );
 }
@@ -469,7 +469,7 @@ ReadParser_iter_reads( PyObject * self, PyObject * args )
 
 static
 PyObject *
-ReadParser_iter_read_pairs( PyObject * self, PyObject * args )
+ReadParser_iter_read_pairs(PyObject * self, PyObject * args )
 {
     int  pair_mode  = IParser:: PAIR_MODE_ERROR_ON_UNPAIRED;
 
@@ -511,11 +511,11 @@ static PyMethodDef _ReadParser_methods [ ] = {
 
 
 static PyTypeObject khmer_ReadParser_Type = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    "khmer.ReadParser",                       /* tp_name */
-    sizeof(khmer_ReadParser_Object),          /* tp_basicsize */
-    0,                                  /* tp_itemsize */
-    (destructor)_ReadParser_dealloc,      /* tp_dealloc */
+    PyVarObject_HEAD_INIT(NULL, 0)             /* init & ob_size */
+    "khmer.ReadParser",                        /* tp_name */
+    sizeof(khmer_ReadParser_Object),           /* tp_basicsize */
+    0,                                         /* tp_itemsize */
+    (destructor)_ReadParser_dealloc,           /* tp_dealloc */
     0,                                         /* tp_print */
     0,                                         /* tp_getattr */
     0,                                         /* tp_setattr */
@@ -530,16 +530,16 @@ static PyTypeObject khmer_ReadParser_Type = {
     0,                                         /* tp_getattro */
     0,                                         /* tp_setattro */
     0,                                         /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT,  /* tp_flags */
+    Py_TPFLAGS_DEFAULT,                        /* tp_flags */
     "Parses streams from various file formats, " \
     "such as FASTA and FASTQ.",                /* tp_doc */
     0,                                         /* tp_traverse */
     0,                                         /* tp_clear */
     0,                                         /* tp_richcompare */
     0,                                         /* tp_weaklistoffset */
-    PyObject_SelfIter,                                         /* tp_iter */
-    (iternextfunc)_ReadParser_iternext,                                         /* tp_iternext */
-    _ReadParser_methods,                  /* tp_methods */
+    PyObject_SelfIter,                         /* tp_iter */
+    (iternextfunc)_ReadParser_iternext,        /* tp_iternext */
+    _ReadParser_methods,                       /* tp_methods */
     0,                                         /* tp_members */
     0,                                         /* tp_getset */
     0,                                         /* tp_base */
@@ -549,10 +549,11 @@ static PyTypeObject khmer_ReadParser_Type = {
     0,                                         /* tp_dictoffset */
     0,                                         /* tp_init */
     0,                                         /* tp_alloc */
-    _ReadParser_new,                      /* tp_new */
+    _ReadParser_new,                           /* tp_new */
 };
 
-/*
+void _init_ReadParser_Type_constants()
+{
     PyObject * cls_attrs_DICT = PyDict_New( );
     if (cls_attrs_DICT == NULL) {
         return;
@@ -588,8 +589,8 @@ static PyTypeObject khmer_ReadParser_Type = {
         return;
     }
 
-    ReadParser_Type.tp_dict     = cls_attrs_DICT;
-*/
+    khmer_ReadParser_Type.tp_dict     = cls_attrs_DICT;
+}
 
 } // namespace python
 
@@ -4634,6 +4635,7 @@ init_khmer(void)
         return;
     }
 
+    _init_ReadParser_Type_constants();
     if (PyType_Ready( &khmer_ReadParser_Type ) < 0) {
         return;
     }

--- a/khmer/_khmermodule.cc
+++ b/khmer/_khmermodule.cc
@@ -633,36 +633,37 @@ typedef struct {
 typedef struct {
     PyObject_HEAD
     SubsetPartition * subset;
-} khmer_KSubsetPartitionObject;
+} khmer_KSubsetPartition_Object;
 
 typedef struct {
     PyObject_HEAD
     Hashbits * hashbits;
 } khmer_KHashbitsObject;
 
-static void khmer_subset_dealloc(PyObject *);
+static void khmer_subset_dealloc(khmer_KSubsetPartition_Object * obj);
 
-static PyTypeObject khmer_KSubsetPartitionType = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    "KSubset", sizeof(khmer_KSubsetPartitionObject),
-    0,
-    khmer_subset_dealloc,   /*tp_dealloc*/
-    0,              /*tp_print*/
-    0,              /*tp_getattr*/
-    0,              /*tp_setattr*/
-    0,              /*tp_compare*/
-    0,              /*tp_repr*/
-    0,              /*tp_as_number*/
-    0,              /*tp_as_sequence*/
-    0,              /*tp_as_mapping*/
-    0,              /*tp_hash */
-    0,              /*tp_call*/
-    0,              /*tp_str*/
-    0,              /*tp_getattro*/
-    0,              /*tp_setattro*/
-    0,              /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT,     /*tp_flags*/
-    "subset object",           /* tp_doc */
+static PyTypeObject khmer_KSubsetPartition_Type = {
+    PyVarObject_HEAD_INIT(NULL, 0)         /* init & ob_size */
+    "khmer.KSubsetPartition",              /* tp_name */
+    sizeof(khmer_KSubsetPartition_Object), /* tp_basicsize */
+    0,                                     /* tp_itemsize */
+    (destructor)khmer_subset_dealloc,      /*tp_dealloc*/
+    0,                                     /*tp_print*/
+    0,                                     /*tp_getattr*/
+    0,                                     /*tp_setattr*/
+    0,                                     /*tp_compare*/
+    0,                                     /*tp_repr*/
+    0,                                     /*tp_as_number*/
+    0,                                     /*tp_as_sequence*/
+    0,                                     /*tp_as_mapping*/
+    0,                                     /*tp_hash */
+    0,                                     /*tp_call*/
+    0,                                     /*tp_str*/
+    0,                                     /*tp_getattro*/
+    0,                                     /*tp_setattro*/
+    0,                                     /*tp_as_buffer*/
+    Py_TPFLAGS_DEFAULT,                    /*tp_flags*/
+    "subset object",                       /* tp_doc */
 };
 
 typedef struct {
@@ -1462,8 +1463,8 @@ static PyObject * hash_do_subset_partition_with_abundance(PyObject * self,
         return PyErr_NoMemory();
     }
 
-    khmer_KSubsetPartitionObject * subset_obj = (khmer_KSubsetPartitionObject *)\
-            PyObject_New(khmer_KSubsetPartitionObject, &khmer_KSubsetPartitionType);
+    khmer_KSubsetPartition_Object * subset_obj = (khmer_KSubsetPartition_Object *)\
+            PyObject_New(khmer_KSubsetPartition_Object, &khmer_KSubsetPartition_Type);
 
     if (subset_obj == NULL) {
         delete subset_p;
@@ -3372,10 +3373,10 @@ static int khmer_hashbits_init(khmer_KHashbitsObject * self, PyObject * args,
 
 ////////////////////////////////////////////////////////////////////////////
 
-static PyObject * subset_count_partitions(PyObject * self,
-        PyObject * args)
+static
+PyObject *
+subset_count_partitions(khmer_KSubsetPartition_Object * me, PyObject * args)
 {
-    khmer_KSubsetPartitionObject * me = (khmer_KSubsetPartitionObject *) self;
     SubsetPartition * subset_p = me->subset;
 
     if (!PyArg_ParseTuple(args, "")) {
@@ -3389,10 +3390,10 @@ static PyObject * subset_count_partitions(PyObject * self,
                          (Py_ssize_t) n_unassigned);
 }
 
-static PyObject * subset_report_on_partitions(PyObject * self,
-        PyObject * args)
+static
+PyObject *
+subset_report_on_partitions(khmer_KSubsetPartition_Object * me, PyObject * args)
 {
-    khmer_KSubsetPartitionObject * me = (khmer_KSubsetPartitionObject *) self;
     SubsetPartition * subset_p = me->subset;
 
     if (!PyArg_ParseTuple(args, "")) {
@@ -3404,10 +3405,10 @@ static PyObject * subset_report_on_partitions(PyObject * self,
     Py_RETURN_NONE;
 }
 
-static PyObject * subset_compare_partitions(PyObject * self,
-        PyObject * args)
+static
+PyObject *
+subset_compare_partitions(khmer_KSubsetPartition_Object * me, PyObject * args)
 {
-    khmer_KSubsetPartitionObject * me = (khmer_KSubsetPartitionObject *) self;
     SubsetPartition * subset1_p = me->subset;
 
     PyObject * subset2_obj = NULL;
@@ -3418,8 +3419,8 @@ static PyObject * subset_compare_partitions(PyObject * self,
         return NULL;
     }
 
-    khmer_KSubsetPartitionObject *other = (khmer_KSubsetPartitionObject *)
-                                          subset2_obj;
+    khmer_KSubsetPartition_Object *other = (khmer_KSubsetPartition_Object *)
+                                           subset2_obj;
     SubsetPartition * subset2_p = other->subset;
 
     unsigned int n_only1 = 0, n_only2 = 0, n_shared = 0;
@@ -3429,10 +3430,11 @@ static PyObject * subset_compare_partitions(PyObject * self,
     return Py_BuildValue("III", n_only1, n_only2, n_shared);
 }
 
-static PyObject * subset_partition_size_distribution(PyObject * self,
-        PyObject * args)
+static
+PyObject *
+subset_partition_size_distribution(khmer_KSubsetPartition_Object * me,
+                                   PyObject * args)
 {
-    khmer_KSubsetPartitionObject * me = (khmer_KSubsetPartitionObject *) self;
     SubsetPartition * subset_p = me->subset;
 
     if (!PyArg_ParseTuple(args, "")) {
@@ -3467,10 +3469,10 @@ static PyObject * subset_partition_size_distribution(PyObject * self,
     return ret;
 }
 
-static PyObject * subset_partition_sizes(PyObject * self,
-        PyObject * args)
+static
+PyObject *
+subset_partition_sizes(khmer_KSubsetPartition_Object * me, PyObject * args)
 {
-    khmer_KSubsetPartitionObject * me = (khmer_KSubsetPartitionObject *) self;
     SubsetPartition * subset_p = me->subset;
 
     unsigned int min_size = 0;
@@ -3513,10 +3515,11 @@ static PyObject * subset_partition_sizes(PyObject * self,
     return ret;
 }
 
-static PyObject * subset_partition_average_coverages(PyObject * self,
-        PyObject * args)
+static
+PyObject *
+subset_partition_average_coverages(khmer_KSubsetPartition_Object * me,
+                                   PyObject * args)
 {
-    khmer_KSubsetPartitionObject * me = (khmer_KSubsetPartitionObject *) self;
     SubsetPartition * subset_p = me->subset;
 
     khmer_KCountingHashObject * counting_o;
@@ -3548,12 +3551,42 @@ static PyObject * subset_partition_average_coverages(PyObject * self,
 }
 
 static PyMethodDef khmer_subset_methods[] = {
-    { "count_partitions", subset_count_partitions, METH_VARARGS, "" },
-    { "report_on_partitions", subset_report_on_partitions, METH_VARARGS, "" },
-    { "compare_partitions", subset_compare_partitions, METH_VARARGS, "" },
-    { "partition_size_distribution", subset_partition_size_distribution, METH_VARARGS, "" },
-    { "partition_sizes", subset_partition_sizes, METH_VARARGS, "" },
-    { "partition_average_coverages", subset_partition_average_coverages, METH_VARARGS, "" },
+    {
+        "count_partitions",
+        (PyCFunction)subset_count_partitions,
+        METH_VARARGS,
+        ""
+    },
+    {
+        "report_on_partitions",
+        (PyCFunction)subset_report_on_partitions,
+        METH_VARARGS,
+        ""
+    },
+    {
+        "compare_partitions",
+        (PyCFunction)subset_compare_partitions,
+        METH_VARARGS,
+        ""
+    },
+    {
+        "partition_size_distribution",
+        (PyCFunction)subset_partition_size_distribution,
+        METH_VARARGS,
+        ""
+    },
+    {
+        "partition_sizes",
+        (PyCFunction)subset_partition_sizes,
+        METH_VARARGS,
+        ""
+    },
+    {
+        "partition_average_coverages",
+        (PyCFunction)subset_partition_average_coverages,
+        METH_VARARGS,
+        ""
+    },
     {NULL, NULL, 0, NULL}           /* sentinel */
 };
 
@@ -4222,13 +4255,11 @@ static void khmer_hashbits_dealloc(PyObject* obj)
 // khmer_subset_dealloc -- clean up a hashbits object.
 //
 
-static void khmer_subset_dealloc(PyObject* self)
+static void khmer_subset_dealloc(khmer_KSubsetPartition_Object * obj)
 {
-    khmer_KSubsetPartitionObject * obj = (khmer_KSubsetPartitionObject *) self;
     delete obj->subset;
     obj->subset = NULL;
-
-    PyObject_Del((PyObject *) obj);
+    Py_TYPE(obj)->tp_free((PyObject*)obj);
 }
 
 
@@ -4604,8 +4635,8 @@ init_khmer(void)
         return;
     }
 
-    khmer_KSubsetPartitionType.tp_methods = khmer_subset_methods;
-    if (PyType_Ready(&khmer_KSubsetPartitionType) < 0) {
+    khmer_KSubsetPartition_Type.tp_methods = khmer_subset_methods;
+    if (PyType_Ready(&khmer_KSubsetPartition_Type) < 0) {
         return;
     }
 

--- a/khmer/_khmermodule.cc
+++ b/khmer/_khmermodule.cc
@@ -203,36 +203,36 @@ static PyGetSetDef khmer_Read_accessors [ ] = {
 
 
 static PyTypeObject khmer_Read_Type = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    "khmer.Read",                       /* tp_name */
-    sizeof(khmer_Read_Object),          /* tp_basicsize */
-    0,                                  /* tp_itemsize */
-    (destructor)khmer_Read_dealloc,      /* tp_dealloc */
-    0,                                         /* tp_print */
-    0,                                         /* tp_getattr */
-    0,                                         /* tp_setattr */
-    0,                                         /* tp_compare */
-    0,                                         /* tp_repr */
-    0,                                         /* tp_as_number */
-    0,                                         /* tp_as_sequence */
-    0,                                         /* tp_as_mapping */
-    0,                                         /* tp_hash */
-    0,                                         /* tp_call */
-    0,                                         /* tp_str */
-    0,                                         /* tp_getattro */
-    0,                                         /* tp_setattro */
-    0,                                         /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT,  /* tp_flags */
-    "A FASTQ record plus some metadata.",      /* tp_doc */
-    0,                                         /* tp_traverse */
-    0,                                         /* tp_clear */
-    0,                                         /* tp_richcompare */
-    0,                                         /* tp_weaklistoffset */
-    0,                                         /* tp_iter */
-    0,                                         /* tp_iternext */
-    0,                                         /* tp_methods */
-    0,                                         /* tp_members */
-    (PyGetSetDef *)khmer_Read_accessors,            /* tp_getset */
+    PyVarObject_HEAD_INIT(NULL, 0)        /* init & ob_size */
+    "khmer.Read",                         /* tp_name */
+    sizeof(khmer_Read_Object),            /* tp_basicsize */
+    0,                                    /* tp_itemsize */
+    (destructor)khmer_Read_dealloc,       /* tp_dealloc */
+    0,                                    /* tp_print */
+    0,                                    /* tp_getattr */
+    0,                                    /* tp_setattr */
+    0,                                    /* tp_compare */
+    0,                                    /* tp_repr */
+    0,                                    /* tp_as_number */
+    0,                                    /* tp_as_sequence */
+    0,                                    /* tp_as_mapping */
+    0,                                    /* tp_hash */
+    0,                                    /* tp_call */
+    0,                                    /* tp_str */
+    0,                                    /* tp_getattro */
+    0,                                    /* tp_setattro */
+    0,                                    /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT,                   /* tp_flags */
+    "A FASTQ record plus some metadata.", /* tp_doc */
+    0,                                    /* tp_traverse */
+    0,                                    /* tp_clear */
+    0,                                    /* tp_richcompare */
+    0,                                    /* tp_weaklistoffset */
+    0,                                    /* tp_iter */
+    0,                                    /* tp_iternext */
+    0,                                    /* tp_methods */
+    0,                                    /* tp_members */
+    (PyGetSetDef *)khmer_Read_accessors,  /* tp_getset */
 };
 
 /***********************************************************************/

--- a/khmer/_khmermodule.cc
+++ b/khmer/_khmermodule.cc
@@ -36,6 +36,15 @@ using namespace khmer;
 #endif
 
 //
+// Python 2/3 compatibility: PyBytes and PyString
+// https://docs.python.org/2/howto/cporting.html#str-unicode-unification
+//
+
+#include "bytesobject.h"
+
+using namespace khmer;
+
+//
 // Function necessary for Python loading:
 //
 
@@ -114,7 +123,7 @@ _debug_class_attrs( PyTypeObject &tobj )
         _trace_logger(
             TraceLogger:: TLVL_DEBUG5,
             "\ttype '%s' dictionary key %d: '%s'\n",
-            tobj.tp_name, pos, PyString_AsString( key )
+            tobj.tp_name, pos, PyBytes_AsString( key )
         );
     }
 #endif // WITH_INTERNAL_TRACING
@@ -181,7 +190,7 @@ _Read_dealloc( PyObject * self )
 
 
 #define KHMER_READ_STRING_GETTER( SELF, ATTR_NAME ) \
-    PyString_FromString( \
+    PyBytes_FromString( \
     ((((Read_Object *)(SELF))->read)->ATTR_NAME).c_str( ) \
     )
 
@@ -1015,8 +1024,8 @@ static PyObject * hash_get(PyObject * self, PyObject * args)
     if (PyInt_Check(arg)) {
         long pos = PyInt_AsLong(arg);
         count = counting->get_count((unsigned int) pos);
-    } else if (PyString_Check(arg)) {
-        std::string s = PyString_AsString(arg);
+    } else if (PyBytes_Check(arg)) {
+        std::string s = PyBytes_AsString(arg);
 
         if (strlen(s.c_str()) != counting->ksize()) {
             PyErr_SetString(PyExc_ValueError,
@@ -1051,7 +1060,7 @@ static PyObject * count_trim_on_abundance(PyObject * self, PyObject * args)
 
     Py_END_ALLOW_THREADS;
 
-    PyObject * trim_seq = PyString_FromStringAndSize(seq, trim_at);
+    PyObject * trim_seq = PyBytes_FromStringAndSize(seq, trim_at);
     if (trim_seq == NULL) {
         return NULL;
     }
@@ -1081,7 +1090,7 @@ static PyObject * count_trim_below_abundance(PyObject * self, PyObject * args)
 
     Py_END_ALLOW_THREADS;
 
-    PyObject * trim_seq = PyString_FromStringAndSize(seq, trim_at);
+    PyObject * trim_seq = PyBytes_FromStringAndSize(seq, trim_at);
     if (trim_seq == NULL) {
         return NULL;
     }
@@ -2072,8 +2081,8 @@ static PyObject * hashbits_get(PyObject * self, PyObject * args)
     if (PyInt_Check(arg)) {
         long pos = PyInt_AsLong(arg);
         count = hashbits->get_count((unsigned int) pos);
-    } else if (PyString_Check(arg)) {
-        std::string s = PyString_AsString(arg);
+    } else if (PyBytes_Check(arg)) {
+        std::string s = PyBytes_AsString(arg);
 
         if (strlen(s.c_str()) < hashbits->ksize()) {
             PyErr_SetString(PyExc_ValueError,
@@ -2151,7 +2160,7 @@ static PyObject * hashbits_trim_on_stoptags(PyObject * self, PyObject * args)
 
     Py_END_ALLOW_THREADS;
 
-    PyObject * trim_seq = PyString_FromStringAndSize(seq, trim_at);
+    PyObject * trim_seq = PyBytes_FromStringAndSize(seq, trim_at);
     if (trim_seq == NULL) {
         return NULL;
     }
@@ -3244,7 +3253,7 @@ static PyObject * hashbits_extract_unique_paths(PyObject * self,
     }
 
     for (unsigned int i = 0; i < results.size(); i++) {
-        PyList_SET_ITEM(x, i, PyString_FromString(results[i].c_str()));
+        PyList_SET_ITEM(x, i, PyBytes_FromString(results[i].c_str()));
     }
 
     return x;
@@ -4535,7 +4544,7 @@ static PyObject * reverse_hash(PyObject * self, PyObject * args)
         return NULL;
     }
 
-    return PyString_FromString(_revhash(val, ksize).c_str());
+    return PyBytes_FromString(_revhash(val, ksize).c_str());
 }
 
 static PyObject * murmur3_forward_hash(PyObject * self, PyObject * args)
@@ -4572,7 +4581,7 @@ get_version_cpp( PyObject * self, PyObject * args )
 #define xstr(s) str(s)
 #define str(s) #s
     std::string dVersion = xstr(VERSION);
-    return PyString_FromString(dVersion.c_str());
+    return PyBytes_FromString(dVersion.c_str());
 }
 
 

--- a/khmer/_khmermodule.cc
+++ b/khmer/_khmermodule.cc
@@ -204,7 +204,7 @@ static PyGetSetDef khmer_Read_accessors [ ] = {
 
 static PyTypeObject khmer_Read_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)        /* init & ob_size */
-    "khmer.Read",                         /* tp_name */
+    "_khmer.Read",                         /* tp_name */
     sizeof(khmer_Read_Object),            /* tp_basicsize */
     0,                                    /* tp_itemsize */
     (destructor)khmer_Read_dealloc,       /* tp_dealloc */
@@ -429,7 +429,7 @@ _ReadPairIterator_iternext(khmer_ReadPairIterator_Object * myself)
 
 static PyTypeObject khmer_ReadPairIterator_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)              /* init & ob_size */
-    "khmer.ReadPairIterator",                   /* tp_name */
+    "_khmer.ReadPairIterator",                   /* tp_name */
     sizeof(khmer_ReadPairIterator_Object),      /* tp_basicsize */
     0,                                          /* tp_itemsize */
     (destructor)khmer_ReadPairIterator_dealloc, /* tp_dealloc */
@@ -512,7 +512,7 @@ static PyMethodDef _ReadParser_methods [ ] = {
 
 static PyTypeObject khmer_ReadParser_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)             /* init & ob_size */
-    "khmer.ReadParser",                        /* tp_name */
+    "_khmer.ReadParser",                        /* tp_name */
     sizeof(khmer_ReadParser_Object),           /* tp_basicsize */
     0,                                         /* tp_itemsize */
     (destructor)_ReadParser_dealloc,           /* tp_dealloc */
@@ -644,7 +644,7 @@ static void khmer_subset_dealloc(khmer_KSubsetPartition_Object * obj);
 
 static PyTypeObject khmer_KSubsetPartition_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)         /* init & ob_size */
-    "khmer.KSubsetPartition",              /* tp_name */
+    "_khmer.KSubsetPartition",              /* tp_name */
     sizeof(khmer_KSubsetPartition_Object), /* tp_basicsize */
     0,                                     /* tp_itemsize */
     (destructor)khmer_subset_dealloc,      /*tp_dealloc*/
@@ -4099,7 +4099,7 @@ static PyMethodDef khmer_labelhash_methods[] = {
 
 static PyTypeObject khmer_KLabelHash_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)  /* init & ob_size */
-    "_khmer._LabelHash",            /* tp_name */
+    "_khmer.LabelHash",            /* tp_name */
     sizeof(khmer_KLabelHash_Object), /* tp_basicsize */
     0,                       /* tp_itemsize */
     (destructor)khmer_labelhash_dealloc, /* tp_dealloc */
@@ -4210,7 +4210,7 @@ static PyObject* khmer_ReadAligner_new(PyTypeObject *type, PyObject * args,
 
 static PyTypeObject khmer_ReadAlignerType = {
     PyVarObject_HEAD_INIT(NULL, 0) /* init & ob_size */
-    "khmer.ReadAligner",		    /*tp_name*/
+    "_khmer.ReadAligner",		    /*tp_name*/
     sizeof(khmer_ReadAligner_Object),	    /*tp_basicsize*/
     0,					    /*tp_itemsize*/
     (destructor)khmer_readaligner_dealloc,  /*tp_dealloc*/
@@ -4482,7 +4482,7 @@ static PyMethodDef khmer_hllcounter_methods[] = {
 
 static PyTypeObject khmer_KHLLCounter_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    "khmer.KHLLCounter",                       /* tp_name */
+    "_khmer.KHLLCounter",                       /* tp_name */
     sizeof(khmer_KHLLCounter_Object),          /* tp_basicsize */
     0,                                         /* tp_itemsize */
     (destructor)khmer_hllcounter_dealloc,      /* tp_dealloc */
@@ -4745,18 +4745,18 @@ init_khmer(void)
     }
 
     Py_INCREF(&khmer_KHashbits_Type);
-    if (PyModule_AddObject(m, "_Hashbits", (PyObject *)&khmer_KHashbits_Type) < 0) {
+    if (PyModule_AddObject(m, "Hashbits", (PyObject *)&khmer_KHashbits_Type) < 0) {
         return;
     }
 
     Py_INCREF(&khmer_KLabelHash_Type);
-    if (PyModule_AddObject(m, "_LabelHash",
+    if (PyModule_AddObject(m, "LabelHash",
                            (PyObject *)&khmer_KLabelHash_Type) < 0) {
         return;
     }
 
     Py_INCREF(&khmer_KHLLCounter_Type);
-    PyModule_AddObject(m, "_HLLCounter", (PyObject *)&khmer_KHLLCounter_Type);
+    PyModule_AddObject(m, "HLLCounter", (PyObject *)&khmer_KHLLCounter_Type);
     Py_INCREF(&khmer_ReadAlignerType);
     PyModule_AddObject(m, "ReadAligner", (PyObject *)&khmer_ReadAlignerType);
 }

--- a/scripts/abundance-dist.py
+++ b/scripts/abundance-dist.py
@@ -65,7 +65,7 @@ def main():
 
     kmer_size = counting_hash.ksize()
     hashsizes = counting_hash.hashsizes()
-    tracking = khmer._new_hashbits(  # pylint: disable=protected-access
+    tracking = khmer._Hashbits(  # pylint: disable=protected-access
         kmer_size, hashsizes)
 
     print ('K:', kmer_size, file=sys.stderr)

--- a/tests/test_counting_hash.py
+++ b/tests/test_counting_hash.py
@@ -291,10 +291,10 @@ def test_save_load():
     ht = khmer.CountingHash(12, sizes)
     ht.load(savepath)
 
-    tracking = khmer._new_hashbits(12, sizes)
+    tracking = khmer._Hashbits(12, sizes)
     x = hi.abundance_distribution(inpath, tracking)
 
-    tracking = khmer._new_hashbits(12, sizes)
+    tracking = khmer._Hashbits(12, sizes)
     y = ht.abundance_distribution(inpath, tracking)
 
     assert sum(x) == 3966, sum(x)
@@ -326,10 +326,10 @@ def test_load_gz():
     ht = khmer.CountingHash(12, sizes)
     ht.load(loadpath)
 
-    tracking = khmer._new_hashbits(12, sizes)
+    tracking = khmer._Hashbits(12, sizes)
     x = hi.abundance_distribution(inpath, tracking)
 
-    tracking = khmer._new_hashbits(12, sizes)
+    tracking = khmer._Hashbits(12, sizes)
     y = ht.abundance_distribution(inpath, tracking)
 
     assert sum(x) == 3966, sum(x)
@@ -350,10 +350,10 @@ def test_save_load_gz():
     ht = khmer.CountingHash(12, sizes)
     ht.load(savepath)
 
-    tracking = khmer._new_hashbits(12, sizes)
+    tracking = khmer._Hashbits(12, sizes)
     x = hi.abundance_distribution(inpath, tracking)
 
-    tracking = khmer._new_hashbits(12, sizes)
+    tracking = khmer._Hashbits(12, sizes)
     y = ht.abundance_distribution(inpath, tracking)
 
     assert sum(x) == 3966, sum(x)

--- a/tests/test_counting_hash.py
+++ b/tests/test_counting_hash.py
@@ -37,7 +37,7 @@ def teardown():
 class Test_CountingHash(object):
 
     def setup(self):
-        self.hi = khmer._new_counting_hash(12, PRIMES_1m)
+        self.hi = khmer.CountingHash(12, PRIMES_1m)
 
     def test_collision_1(self):
 
@@ -114,7 +114,7 @@ def test_3_tables():
     x = list(PRIMES_1m)
     x.append(1000005)
 
-    hi = khmer._new_counting_hash(12, x)
+    hi = khmer.CountingHash(12, x)
 
     GG = 'G' * 12                   # forward_hash: 11184810
     assert khmer.forward_hash(GG, 12) == 11184810
@@ -284,11 +284,11 @@ def test_save_load():
     sizes = list(PRIMES_1m)
     sizes.append(1000005)
 
-    hi = khmer._new_counting_hash(12, sizes)
+    hi = khmer.CountingHash(12, sizes)
     hi.consume_fasta(inpath)
     hi.save(savepath)
 
-    ht = khmer._new_counting_hash(12, sizes)
+    ht = khmer.CountingHash(12, sizes)
     ht.load(savepath)
 
     tracking = khmer._new_hashbits(12, sizes)
@@ -311,7 +311,7 @@ def test_load_gz():
     sizes.append(1000005)
 
     # save uncompressed hashtable.
-    hi = khmer._new_counting_hash(12, sizes)
+    hi = khmer.CountingHash(12, sizes)
     hi.consume_fasta(inpath)
     hi.save(savepath)
 
@@ -323,7 +323,7 @@ def test_load_gz():
     in_file.close()
 
     # load compressed hashtable.
-    ht = khmer._new_counting_hash(12, sizes)
+    ht = khmer.CountingHash(12, sizes)
     ht.load(loadpath)
 
     tracking = khmer._new_hashbits(12, sizes)
@@ -343,11 +343,11 @@ def test_save_load_gz():
     sizes = list(PRIMES_1m)
     sizes.append(1000005)
 
-    hi = khmer._new_counting_hash(12, sizes)
+    hi = khmer.CountingHash(12, sizes)
     hi.consume_fasta(inpath)
     hi.save(savepath)
 
-    ht = khmer._new_counting_hash(12, sizes)
+    ht = khmer.CountingHash(12, sizes)
     ht.load(savepath)
 
     tracking = khmer._new_hashbits(12, sizes)
@@ -752,7 +752,7 @@ def test_counting_gz_file_type_check():
 
 def test_counting_bad_primes_list():
     try:
-        ht = khmer._new_counting_hash(12, ["a", "b", "c"], 1)
+        ht = khmer.CountingHash(12, ["a", "b", "c"], 1)
         assert 0, "bad list of primes should fail"
     except TypeError as e:
         print str(e)

--- a/tests/test_hashbits.py
+++ b/tests/test_hashbits.py
@@ -742,7 +742,7 @@ def test_tagset_filetype_check():
 
 def test_bad_primes_list():
     try:
-        coutingtable = khmer._new_hashbits(31, ["a", "b", "c"], 1)
+        coutingtable = khmer._Hashbits(31, ["a", "b", "c"], 1)
         assert 0, "Bad primes list should fail"
     except TypeError as e:
         print str(e)


### PR DESCRIPTION
Update extension to pave the way for the future :wink:
PyLong instead of PyInt, Type initialization, PyBytes instead of PyString.
Replace common initialization with explicit type structs, and all types conform to the CPython checklist.

This fixes #38 and #728. The only item missing from #728 checklist is changing references from 'hash' to 'table' in all methods. All classes are also conforming to the CPython checklist.

TODO:
  - [x] `ReadParser_Type`: expose constants in tp_dict


Remaining questions:
- Do we define `tp_new` for 'read-only' types, like `ReadPairIterator_Type` and `Read_Type`? They can't be constructed on Python land at the moment, and reflect internal components from C++ structures. (`khmer_KSubsetPartitionType` is also missing `tp_new`, but it is probably appropriate to deal with it in #802.)

- Missing documentation for methods: see #832

- `khmer_KHashbitsType`: Some methods deal with SubsetPartition, but doesn't touch the Hashbits directly. See #833