### PR TITLE
Corrected spelling errors in doc/dev/coding-guidelines-and-review.txt

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -10,12 +10,6 @@
 
 2015-02-19  Daniel Standage  <daniel.standage@gmail.com>
 
-   * doc/dev/coding-guidelines-and-review.txt: added checklist for new CPython
-   types
-   * khmer/_khmermodule.cc: Update ReadAligner to follow the new guidelines
-
-2015-02-19  Daniel Standage  <daniel.standage@gmail.com>
-
    * Makefile: add a new Makefile target `help` to list and describe all
    common targets.
    * khmer/utils.py, tests/test_functions.py: minor style fixes.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,14 @@
+2015-02-20  Aditi Gupta  <agupta@msu.edu>
+
+   * doc/dev/coding-guidelines-and-review.txt: fixed spelling errors.
+
 2015-02-19  Michael R. Crusoe  <mcrusoe@msu.edu>
+
+   * doc/dev/coding-guidelines-and-review.txt: added checklist for new CPython
+   types
+   * khmer/_khmermodule.cc: Update ReadAligner to follow the new guidelines
+
+2015-02-19  Daniel Standage  <daniel.standage@gmail.com>
 
    * doc/dev/coding-guidelines-and-review.txt: added checklist for new CPython
    types

--- a/doc/dev/coding-guidelines-and-review.txt
+++ b/doc/dev/coding-guidelines-and-review.txt
@@ -58,7 +58,7 @@ Checklist
 Copy and paste the following into a pull request comment when it is
 ready for review::
    
-   - [ ] Is it mergable?
+   - [ ] Is it mergeable?
    - [ ] Did it pass the tests?
    - [ ] If it introduces new functionality in scripts/ is it tested?
      Check for code coverage with `make clean diff-cover`
@@ -80,7 +80,7 @@ in the middle.
 CPython Checklist
 -----------------
 
-Here's a checklist for new CPython types with futureproofing for Python 3::
+Here's a checklist for new CPython types with future-proofing for Python 3::
 
    - [ ] the CPython object name is of the form `khmer_${OBJECTNAME}_Object`
    - [ ] Named struct with `PyObject_HEAD` macro


### PR DESCRIPTION
Fixed spellings in doc/dev/coding-guidelines-and-review.txt. Fixes issue #801.

- [x] Is it mergable?
- [x] Did it pass the tests?
- [x] If it introduces new functionality in scripts/ is it tested?
  Check for code coverage with `make clean diff-cover`
- [x] Is it well formatted? Look at `make pep8`, `make diff_pylint_report`,
  `make cppcheck`, and `make doc` output. Use `make format` and manual
  fixing as needed.
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Is it documented in the ChangeLog?
  http://en.wikipedia.org/wiki/Changelog#Format
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
