### PR TITLE
Make interleave-reads.py print output name nicely

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2015-02-24  Kevin Murray  <spam@kdmurray.id.au>
+
+   * scripts/interleave-reads.py: Make the output file name print nicely.
+
 2015-02-23  Titus Brown  <titus@idyll.org>
 
    * khmer/utils.py: added 'check_is_left' and 'check_is_right' functions;

--- a/scripts/interleave-reads.py
+++ b/scripts/interleave-reads.py
@@ -127,7 +127,7 @@ def main():
         write_record_pair(read1, read2, args.output)
 
     print >> sys.stderr, 'final: interleaved %d pairs' % counter
-    print >> sys.stderr, 'output written to', args.output
+    print >> sys.stderr, 'output written to', args.output.name
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Currently, interleave-reads.py just prints the open file object. Now, it
will print output.name, i.e. the file path (or `<stdout>` for stdout)