### PR TITLE
set 'force' to default to False on kfile.check_file_status.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,11 @@
    * tests/test_scripts.py: add a test for the --append option in
    normalize-by-median.py
 
+2015-02-25  Titus Brown  <titus@idyll.org>
+
+   * khmer/kfile.py: set 'force' flag for 'check_file_status' to default to
+   'False'.
+
 2015-02-25  Hussien Alameldin  <hussien@msu.edu>
 
    * khmer/khmer_args.py: add 'hll' citation entry "Irber and Brown,

--- a/khmer/kfile.py
+++ b/khmer/kfile.py
@@ -14,7 +14,7 @@ import sys
 from stat import S_ISBLK, S_ISFIFO
 
 
-def check_file_status(file_path, force):
+def check_file_status(file_path, force=False):
     """Check the status of the file; if the file is empty or doesn't exist
     AND if the file is NOT a fifo/block/named pipe then a warning is printed
     and sys.exit(1) is called


### PR DESCRIPTION
minor fix for some sandbox scripts, but I think this is a good default for this function.

#772 should test for this - I don't want to step all over @jessicamizzi's code :)