### PR TITLE
CVS output to abundance-test-single.py

### DIFF
--- a/scripts/abundance-dist-single.py
+++ b/scripts/abundance-dist-single.py
@@ -55,6 +55,8 @@ def get_parser():
     parser.add_argument('-s', '--squash', dest='squash_output', default=False,
                         action='store_true',
                         help='Overwrite output file if it exists')
+    parser.add_argument('--csv', default=False, action='store_true',
+                        help='Use the CSV format for the histogram. '
     parser.add_argument('--savetable', default='', metavar="filename",
                         help="Save the k-mer counting table to the specified "
                         "filename.")
@@ -83,6 +85,11 @@ def main():  # pylint: disable=too-many-locals,too-many-branches
         sys.exit(1)
     else:
         hist_fp = open(args.output_histogram_filename, 'w')
+        if args.csv:
+        hash_fp_csv = csv.writer(hash_fp)
+        # write headers:
+        hash_fp_csv.writerow(['abundance', 'count', 'cumulative',
+                              'cumulative_fraction'])
 
     print >>sys.stderr, 'making k-mer counting table'
     counting_hash = khmer.new_counting_hash(args.ksize, args.min_tablesize,
@@ -167,7 +174,10 @@ def main():  # pylint: disable=too-many-locals,too-many-branches
         sofar += i
         frac = sofar / float(total)
 
-        print >> hist_fp, _, i, sofar, round(frac, 3)
+        if args.csv:
+            hash_fp_csv.writerow([_, i, sofar, round(frac, 3)])
+        else:
+            print >> hist_fp, _, i, sofar, round(frac, 3)
 
         if sofar == total:
             break

--- a/scripts/abundance-dist-single.py
+++ b/scripts/abundance-dist-single.py
@@ -87,10 +87,10 @@ def main():  # pylint: disable=too-many-locals,too-many-branches
     else:
         hist_fp = open(args.output_histogram_filename, 'w')
         if args.csv:
-        hash_fp_csv = csv.writer(hash_fp)
-        # write headers:
-        hash_fp_csv.writerow(['abundance', 'count', 'cumulative',
-                              'cumulative_fraction'])
+            hash_fp_csv = csv.writer(hash_fp)
+            # write headers:
+            hash_fp_csv.writerow(['abundance', 'count', 'cumulative',
+                                  'cumulative_fraction'])
 
     print >>sys.stderr, 'making k-mer counting table'
     counting_hash = khmer.new_counting_hash(args.ksize, args.min_tablesize,

--- a/scripts/abundance-dist-single.py
+++ b/scripts/abundance-dist-single.py
@@ -57,6 +57,7 @@ def get_parser():
                         help='Overwrite output file if it exists')
     parser.add_argument('--csv', default=False, action='store_true',
                         help='Use the CSV format for the histogram. '
+                        'Includes column headers.')
     parser.add_argument('--savetable', default='', metavar="filename",
                         help="Save the k-mer counting table to the specified "
                         "filename.")

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1441,6 +1441,29 @@ def test_abundance_dist_single():
     assert line == '1001 2 98 1.0', line
 
 
+def test_abundance_dist_single_csv():
+    infile = utils.get_temp_filename('test.fa')
+    outfile = utils.get_temp_filename('test.dist')
+    in_dir = os.path.dirname(infile)
+
+    shutil.copyfile(utils.get_test_data('test-abund-read-2.fa'), infile)
+
+    script = scriptpath('abundance-dist-single.py')
+    args = ['-x', '1e7', '-N', '2', '-k', '17', '-z', '--csv', infile,
+            outfile]
+    (status, out, err) = utils.runscript(script, args, in_dir)
+
+    assert 'Total number of unique k-mers: 98' in err, err
+
+    fp = iter(open(outfile))
+    line = fp.next().strip()
+    assert (line == 'abundance,count,cumulative,cumulative_fraction'), line
+    line = fp.next().strip()
+    assert line == '1 96 96 0.98', line
+    line = fp.next().strip()
+    assert line == '1001 2 98 1.0', line
+
+
 def test_abundance_dist_single_nobigcount():
     infile = utils.get_temp_filename('test.fa')
     outfile = utils.get_temp_filename('test.dist')


### PR DESCRIPTION
In abundance-dist-single.py: Use CSV format for the histogram. Includes column headers.
And add a test function for the --csv option in test_scripts.py