### PR TITLE
Make the help text of load-into-counting's '-b' flag more verbose

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2015-02-27  Kevin Murray  <spam@kdmurray.id.au>
+
+   * scripts/load-into-counting.py: Be verbose in the help text, to clarify
+   what the -b flag does.
+
 2015-02-25  Hussien Alameldin  <hussien@msu.edu>
 
    * sandbox/bloom_count.py: renamed to bloom-count.py

--- a/scripts/load-into-counting.py
+++ b/scripts/load-into-counting.py
@@ -54,8 +54,9 @@ def get_parser():
                         help="The names of one or more FAST[AQ] input "
                         "sequence files.")
     parser.add_argument('-b', '--no-bigcount', dest='bigcount', default=True,
-                        action='store_false',
-                        help='Do not count k-mers past 255')
+                        action='store_false', help="The default behaviour is "
+                        "to count past 255 using bigcount. This flag turns "
+                        "this off, limiting counts to 255.")
     parser.add_argument('--summary-info', '-s', default=None, metavar="FORMAT",
                         choices=['json', 'tsv'],
                         help="What format should the machine readable run "

--- a/scripts/load-into-counting.py
+++ b/scripts/load-into-counting.py
@@ -56,7 +56,7 @@ def get_parser():
     parser.add_argument('-b', '--no-bigcount', dest='bigcount', default=True,
                         action='store_false', help="The default behaviour is "
                         "to count past 255 using bigcount. This flag turns "
-                        "this off, limiting counts to 255.")
+                        "bigcount off, limiting counts to 255.")
     parser.add_argument('--summary-info', '-s', default=None, metavar="FORMAT",
                         choices=['json', 'tsv'],
                         help="What format should the machine readable run "


### PR DESCRIPTION
Hi all,

I confused myself this morning while trying to work out the effect of -b in load-into-counting.  Admittedly I was having a bit of a slow morning, but I got confused by the `--no-bigcounts (default=True)` help message. Does default=True mean that it's off or on by default?

This PR explains the behavior more verbosely in the help string, hopefully proofing against coffee deprived users :smile:.

Cheers,
K