### PR TITLE
Skip the get_raw_tables test if python doesn't  have memoryview

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,8 +1,12 @@
+2015-03-15  Kevin Murray  <spam@kdmurray.id.au>  &  Titus Brown  <titus@idyll.org>
+
+   * tests/test_counting_hash.py: Skip get_raw_tables test if python doesn't
+   have the memoryview type/function.
 
 2015-03-11  Erich Schwarz  <ems394@cornell.edu>
 
-   * Added URLs and brief descriptions for khmer-relevant documentation in 
-   doc/introduction.txt, pointing to http://khmer-protocols.readthedocs.org and 
+   * Added URLs and brief descriptions for khmer-relevant documentation in
+   doc/introduction.txt, pointing to http://khmer-protocols.readthedocs.org and
    khmer-recipes.readthedocs.org, with brief descriptions of their content.
 
 2015-03-10  Camille Scott  <camille.scott.w@gmail.com>

--- a/khmer/_khmermodule.cc
+++ b/khmer/_khmermodule.cc
@@ -688,7 +688,7 @@ hash_get_raw_tables(khmer_KCountingHash_Object * self, PyObject * args)
 {
     CountingHash * counting = self->counting;
 
-    Byte ** table_ptrs = counting->get_raw_tables();
+    khmer::Byte ** table_ptrs = counting->get_raw_tables();
     std::vector<HashIntoType> sizes = counting->get_tablesizes();
 
     PyObject * raw_tables = PyList_New(sizes.size());

--- a/tests/test_counting_hash.py
+++ b/tests/test_counting_hash.py
@@ -119,7 +119,10 @@ def test_get_raw_tables_view():
     ht = khmer.new_counting_hash(20, 1e5, 4)
     tables = ht.get_raw_tables()
     for tab in tables:
-        memv = memoryview(tab)
+        try:
+            memv = memoryview(tab)
+        except TypeError:
+            raise nose.SkipTest("This test needs a higher version of Python.")
         assert sum(memv.tolist()) == 0
     ht.consume('AAAATTTTCCCCGGGGAAAA')
     for tab in tables:

--- a/tests/test_counting_hash.py
+++ b/tests/test_counting_hash.py
@@ -12,6 +12,7 @@ import khmer_tst_utils as utils
 from khmer import ReadParser
 import screed
 
+import nose
 from nose.plugins.attrib import attr
 
 MAX_COUNT = 255
@@ -111,6 +112,10 @@ def test_get_raw_tables():
 
 
 def test_get_raw_tables_view():
+    try:
+        memoryview
+    except NameError:
+        raise nose.SkipTest("This test requires memoryview")
     ht = khmer.new_counting_hash(20, 1e5, 4)
     tables = ht.get_raw_tables()
     for tab in tables:


### PR DESCRIPTION
This addresses @luizirber's comment in #868 that python2.6 chokes on this test.