### PR TITLE
Thread-safety for hashtable

### DIFF
--- a/lib/counting.hh
+++ b/lib/counting.hh
@@ -94,6 +94,17 @@ public:
         return _counts;
     }
 
+    virtual void init_threadstuff(unsigned int block_size=TABLE_BLOCK_SIZE) {
+        HashIntoType _max_size = _tablesizes.back();
+        _n_table_blocks = (_max_size < block_size) ? 1 : (_max_size / block_size);
+        //std::cout << "Table lock blocks: " << _n_table_blocks << std::endl;
+        _table_spinlocks = new uint32_t[_n_table_blocks];
+        for (unsigned int i=0; i<_n_table_blocks; ++i) {
+            _table_spinlocks[i] = 0;
+        }
+        _threadsafe = true;
+    }
+
     virtual BoundedCounterType test_and_set_bits(const char * kmer)
     {
         BoundedCounterType x = get_count(kmer); // @CTB just hash it, yo.
@@ -196,6 +207,45 @@ public:
         }
 
     } // count
+
+    // Thread-safe counting function
+    virtual void count_ts(HashIntoType khash)
+    {
+        bool is_new_kmer = true;
+        unsigned int  n_full      = 0;
+        uint32_t lock_index = khash % _n_table_blocks;
+        while(!__sync_bool_compare_and_swap( &_table_spinlocks[lock_index], 0, 1));
+        for (unsigned int i = 0; i < _n_tables; i++) {
+            const HashIntoType bin = khash % _tablesizes[i];
+            Byte current_count = _counts[ i ][ bin ];
+            if (is_new_kmer && current_count != 0) {
+                is_new_kmer = false;
+            }
+            if ( _max_count > current_count ) {
+                __sync_add_and_fetch( *(_counts + i) + bin, 1 );
+            } else {
+                n_full++;
+            }
+        } // for each table
+        __sync_bool_compare_and_swap( &_table_spinlocks[lock_index], 1, 0);
+
+        if (n_full == _n_tables && _use_bigcount) {
+            while (!__sync_bool_compare_and_swap( &_bigcount_spin_lock, 0, 1 ));
+            if (_bigcounts[khash] == 0) {
+                _bigcounts[khash] = _max_count + 1;
+            } else {
+                if (_bigcounts[khash] < _max_bigcount) {
+                    _bigcounts[khash] += 1;
+                }
+            }
+            __sync_bool_compare_and_swap( &_bigcount_spin_lock, 1, 0 );
+        }
+
+        if (is_new_kmer) {
+            __sync_add_and_fetch(&_n_unique_kmers, 1);
+        }
+
+    } // count_ts
 
     // get the count for the given k-mer.
     virtual const BoundedCounterType get_count(const char * kmer) const

--- a/lib/hashtable.hh
+++ b/lib/hashtable.hh
@@ -27,6 +27,7 @@
 #include "kmer_hash.hh"
 
 #define MAX_KEEPER_SIZE int(1e6)
+#define TABLE_BLOCK_SIZE 10000
 
 #define next_f(kmer_f, ch) ((((kmer_f) << 2) & bitmask) | (twobit_repr(ch)))
 #define next_r(kmer_r, ch) (((kmer_r) >> 2) | (twobit_comp(ch) << rc_left_shift))
@@ -184,6 +185,10 @@ protected:
     HashIntoType    bitmask;
     unsigned int    _nbits_sub_1;
 
+    uint32_t * _table_spinlocks;
+    HashIntoType _n_table_blocks;
+    bool _threadsafe;
+
     Hashtable( WordLength ksize )
         : _max_count( MAX_KCOUNT ),
           _max_bigcount( MAX_BIGCOUNT ),
@@ -196,7 +201,7 @@ protected:
         partition = new SubsetPartition(this);
         _init_bitstuff();
         _all_tags_spin_lock = 0;
-
+        _threadsafe = false;
     }
 
     virtual ~Hashtable( )
@@ -256,7 +261,11 @@ public:
 
     virtual void count(const char * kmer) = 0;
     virtual void count(HashIntoType khash) = 0;
-
+    virtual void count_ts(HashIntoType khash) {};
+    
+    virtual void init_threadstuff(unsigned int block_size=TABLE_BLOCK_SIZE) {};
+    bool is_threadsafe() { return _threadsafe; };
+    
     // get the count for the given k-mer.
     virtual const BoundedCounterType get_count(const char * kmer) const = 0;
     virtual const BoundedCounterType get_count(HashIntoType khash) const = 0;


### PR DESCRIPTION
The multithreading PR has gotten unwieldy, so this is part of the process to break it down into more manageable chunks. This set of commits adds an array of locks to Hashtable with are indexed by the hashvalue, allowing a thread to lock only a small block when writing. It also introduces a new function meant specifically for thread-safe counting, to avoid overhead under single-threaded cases and maintain backwards compatibility.