### PR TITLE
Initial implementation of read counting in C++  read parser

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2015-03-31  Kevin Murray  <spam@kdmurray.id.au>
+
+   * lib/read_parsers.{cc,hh}: add read counting to IParser and subclasses
+   * khmer/_khmermodule.cc,tests/test_read_parsers.py: add 'num_reads'
+   attribute to khmer.ReadParser objects in python land, and test it.
+
 2015-03-28  Kevin Murray  <spam@kdmurray.id.au>
 
    * lib/hashbits.hh: Add Hashbits::n_tables() accessor

--- a/khmer/_khmermodule.cc
+++ b/khmer/_khmermodule.cc
@@ -466,6 +466,20 @@ ReadParser_iter_reads(PyObject * self, PyObject * args )
     return PyObject_SelfIter( self );
 }
 
+static
+PyObject *
+ReadParser_get_num_reads(khmer_ReadParser_Object * me, PyObject * args)
+{
+    read_parsers:: IParser *  parser = me->parser;
+
+    if (!PyArg_ParseTuple(args, "")) {
+        return NULL;
+    }
+
+    unsigned long n_reads = parser->get_num_reads();
+
+    return PyLong_FromLong(n_reads);
+}
 
 static
 PyObject *
@@ -504,6 +518,10 @@ static PyMethodDef _ReadParser_methods [ ] = {
     {
         "iter_read_pairs",  (PyCFunction)ReadParser_iter_read_pairs,
         METH_VARARGS,       "Iterates over paired reads as pairs."
+    },
+    {
+        "get_num_reads",  (PyCFunction)ReadParser_get_num_reads,
+        METH_VARARGS,       "Returns the current number of reads processed."
     },
 
     { NULL, NULL, 0, NULL } // sentinel

--- a/khmer/_khmermodule.cc
+++ b/khmer/_khmermodule.cc
@@ -468,17 +468,9 @@ ReadParser_iter_reads(PyObject * self, PyObject * args )
 
 static
 PyObject *
-ReadParser_get_num_reads(khmer_ReadParser_Object * me, PyObject * args)
+ReadParser_get_num_reads(khmer_ReadParser_Object * me)
 {
-    read_parsers:: IParser *  parser = me->parser;
-
-    if (!PyArg_ParseTuple(args, "")) {
-        return NULL;
-    }
-
-    unsigned long n_reads = parser->get_num_reads();
-
-    return PyLong_FromLong(n_reads);
+    return PyLong_FromLong(me->parser->get_num_reads());
 }
 
 static
@@ -519,14 +511,18 @@ static PyMethodDef _ReadParser_methods [ ] = {
         "iter_read_pairs",  (PyCFunction)ReadParser_iter_read_pairs,
         METH_VARARGS,       "Iterates over paired reads as pairs."
     },
-    {
-        "get_num_reads",  (PyCFunction)ReadParser_get_num_reads,
-        METH_VARARGS,       "Returns the current number of reads processed."
-    },
-
     { NULL, NULL, 0, NULL } // sentinel
 };
 
+static PyGetSetDef khmer_ReadParser_accessors[] = {
+    {
+        (char *)"num_reads",
+        (getter)ReadParser_get_num_reads, NULL,
+        (char *)"count of reads processed thus far.",
+        NULL
+    },
+    {NULL, NULL, NULL, NULL, NULL} /* Sentinel */
+};
 
 static PyTypeObject khmer_ReadParser_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)             /* init & ob_size */
@@ -559,7 +555,7 @@ static PyTypeObject khmer_ReadParser_Type = {
     (iternextfunc)_ReadParser_iternext,        /* tp_iternext */
     _ReadParser_methods,                       /* tp_methods */
     0,                                         /* tp_members */
-    0,                                         /* tp_getset */
+    khmer_ReadParser_accessors,                /* tp_getset */
     0,                                         /* tp_base */
     0,                                         /* tp_dict */
     0,                                         /* tp_descr_get */

--- a/lib/read_parsers.cc
+++ b/lib/read_parsers.cc
@@ -41,6 +41,7 @@ SeqAnParser::SeqAnParser( char const * filename ) : IParser( )
     }
     __asm__ __volatile__ ("" ::: "memory");
     _private->seqan_spin_lock = 0;
+    _num_reads = 0;
 }
 
 bool SeqAnParser::is_complete()
@@ -57,6 +58,7 @@ void SeqAnParser::imprint_next_read(Read &the_read)
     if (!atEnd) {
         ret = seqan::readRecord(the_read.name, the_read.sequence,
                                 the_read.quality, _private->stream);
+        _num_reads++;
     }
     __asm__ __volatile__ ("" ::: "memory");
     _private->seqan_spin_lock = 0;
@@ -115,6 +117,7 @@ IParser(
     if (regex_rc) {
         throw khmer_exception();
     }
+    _num_reads = 0;
 }
 
 IParser::

--- a/lib/read_parsers.cc
+++ b/lib/read_parsers.cc
@@ -58,7 +58,9 @@ void SeqAnParser::imprint_next_read(Read &the_read)
     if (!atEnd) {
         ret = seqan::readRecord(the_read.name, the_read.sequence,
                                 the_read.quality, _private->stream);
-        _num_reads++;
+        if (ret == 0) {
+            _num_reads++;
+        }
     }
     __asm__ __volatile__ ("" ::: "memory");
     _private->seqan_spin_lock = 0;

--- a/lib/read_parsers.cc
+++ b/lib/read_parsers.cc
@@ -41,7 +41,6 @@ SeqAnParser::SeqAnParser( char const * filename ) : IParser( )
     }
     __asm__ __volatile__ ("" ::: "memory");
     _private->seqan_spin_lock = 0;
-    _num_reads = 0;
 }
 
 bool SeqAnParser::is_complete()

--- a/lib/read_parsers.hh
+++ b/lib/read_parsers.hh
@@ -84,8 +84,14 @@ struct IParser {
         uint8_t mode = PAIR_MODE_ERROR_ON_UNPAIRED
     );
 
+    size_t		    get_num_reads()
+    {
+	    return _num_reads;
+    }
+
 protected:
 
+    size_t		_num_reads;
     regex_t		_re_read_2_nosub;
     regex_t		_re_read_1;
     regex_t		_re_read_2;

--- a/tests/test_read_parsers.py
+++ b/tests/test_read_parsers.py
@@ -45,6 +45,35 @@ def test_with_default_arguments():
         assert m == n
 
 
+def test_get_num_reads():
+    reads_count = 0
+    rparser = ReadParser(utils.get_test_data("100-reads.fq.gz"))
+    for read in rparser:
+        reads_count += 1
+
+    assert reads_count == 100
+    assert rparser.get_num_reads() == 100
+
+@attr('multithread')
+def test_get_num_reads_threads():
+    import threading
+
+    def count_reads(rparser):
+        for read in rparser:
+            pass
+
+    N_THREADS = 4
+    threads = []
+    rparser = ReadParser(utils.get_test_data("100-reads.fq.gz"))
+    for tnum in xrange(N_THREADS):
+        t = threading.Thread(target=count_reads, args=[rparser,])
+        threads.append(t)
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert rparser.get_num_reads() == 100
+
 def test_gzip_decompression():
 
     reads_count = 0

--- a/tests/test_read_parsers.py
+++ b/tests/test_read_parsers.py
@@ -45,19 +45,19 @@ def test_with_default_arguments():
         assert m == n
 
 
-def test_get_num_reads():
-    """Test ReadParser.get_num_reads()"""
+def test_num_reads():
+    """Test ReadParser.num_reads"""
     reads_count = 0
     rparser = ReadParser(utils.get_test_data("100-reads.fq.gz"))
     for _ in rparser:
         reads_count += 1
 
     assert reads_count == 100
-    assert rparser.get_num_reads() == 100
+    assert rparser.num_reads == 100
 
 
 @attr('multithread')
-def test_get_num_reads_threads():
+def test_num_reads_threads():
     """Test threadsaftey of ReadParser's read counting"""
     import threading
 
@@ -75,7 +75,7 @@ def test_get_num_reads_threads():
     for thr in threads:
         thr.join()
 
-    assert rparser.get_num_reads() == 100
+    assert rparser.num_reads == 100
 
 
 def test_gzip_decompression():

--- a/tests/test_read_parsers.py
+++ b/tests/test_read_parsers.py
@@ -46,9 +46,10 @@ def test_with_default_arguments():
 
 
 def test_get_num_reads():
+    """Test ReadParser.get_num_reads()"""
     reads_count = 0
     rparser = ReadParser(utils.get_test_data("100-reads.fq.gz"))
-    for read in rparser:
+    for _ in rparser:
         reads_count += 1
 
     assert reads_count == 100
@@ -57,21 +58,22 @@ def test_get_num_reads():
 
 @attr('multithread')
 def test_get_num_reads_threads():
+    """Test threadsaftey of ReadParser's read counting"""
     import threading
 
     def count_reads(rparser):
-        for read in rparser:
+        for _ in rparser:
             pass
 
-    N_THREADS = 4
+    n_threads = 4
     threads = []
     rparser = ReadParser(utils.get_test_data("100-reads.fq.gz"))
-    for tnum in xrange(N_THREADS):
-        t = threading.Thread(target=count_reads, args=[rparser, ])
-        threads.append(t)
-        t.start()
-    for t in threads:
-        t.join()
+    for _ in xrange(n_threads):
+        thr = threading.Thread(target=count_reads, args=[rparser, ])
+        threads.append(thr)
+        thr.start()
+    for thr in threads:
+        thr.join()
 
     assert rparser.get_num_reads() == 100
 

--- a/tests/test_read_parsers.py
+++ b/tests/test_read_parsers.py
@@ -54,6 +54,7 @@ def test_get_num_reads():
     assert reads_count == 100
     assert rparser.get_num_reads() == 100
 
+
 @attr('multithread')
 def test_get_num_reads_threads():
     import threading
@@ -66,7 +67,7 @@ def test_get_num_reads_threads():
     threads = []
     rparser = ReadParser(utils.get_test_data("100-reads.fq.gz"))
     for tnum in xrange(N_THREADS):
-        t = threading.Thread(target=count_reads, args=[rparser,])
+        t = threading.Thread(target=count_reads, args=[rparser, ])
         threads.append(t)
         t.start()
     for t in threads:
@@ -74,8 +75,8 @@ def test_get_num_reads_threads():
 
     assert rparser.get_num_reads() == 100
 
-def test_gzip_decompression():
 
+def test_gzip_decompression():
     reads_count = 0
     rparser = ReadParser(utils.get_test_data("100-reads.fq.gz"))
     for read in rparser:


### PR DESCRIPTION
Hi all,

I've been thinking about #676, and decided to jump right in with one pre-requisite of metadata reporting, counting reads.

This is an implementation of read counting for the C++ parser(s), and an accessor for python-land objects.

It appears threadsafe, from my hacky testing (increments are done within spinlocked code blocks). I'll test further, and write tests etc as time permits :)

Cheers,
K