### PR TITLE
Add CountingHash::n_tables() accessor

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2015-03-23  Kevin Murray  <spam@kdmurray.id.au>
+
+   * lib/counting.hh: Add CountingHash::n_tables() accessor
+
 2015-03-16  Jessica Mizzi  <mizzijes@msu.edu>
 
     * khmer/kfile.py: Added file not existing error for system exit

--- a/lib/counting.hh
+++ b/lib/counting.hh
@@ -133,6 +133,11 @@ public:
         return _tablesizes[0];
     }
 
+    const size_t n_tables() const
+    {
+        return _n_tables;
+    }
+
     // count number of occupied bins
     virtual const HashIntoType n_occupied(HashIntoType start=0,
                                           HashIntoType stop=0) const


### PR DESCRIPTION
Purely for convenience & efficiency.

I've been doing a lot of hacking on khmer in CPP land lately, and having to do `countinghash->get_tablesizes().size()` is quite verbose (and involves an inefficient vector copy doesn't it?).

Now, one can do `countinghash->n_tables()`, in the vein of `countinghash->n_entries()`.