### PR TITLE
Add n_tables accessor to Hashbits

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2015-03-28  Kevin Murray  <spam@kdmurray.id.au>
+
+   * lib/hashbits.hh: Add Hashbits::n_tables() accessor
+
 2015-03-27  Michael R. Crusoe  <mcrusoe@msu.edu>
 
    * lib/read_parsers.{cc,hh}: Obfuscate SeqAn SequenceStream objects with a

--- a/lib/hashbits.hh
+++ b/lib/hashbits.hh
@@ -68,9 +68,15 @@ public:
 
     }
 
+    // Accessors for protected/private table info members
     std::vector<HashIntoType> get_tablesizes() const
     {
         return _tablesizes;
+    }
+
+    const size_t n_tables() const
+    {
+        return _n_tables;
     }
 
     virtual void save(std::string);


### PR DESCRIPTION
Companion to #879


This adds `khmer::Hashbits::n_tables()` as a convenience method.