### PR TITLE
Throw exception on weird seqan parsing of truncated file

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2015-04-05  Kevin Murray  <spam@kdmurray.id.au>
+
+   * lib/read_parsers.{cc,hh}: Work around an issue (#884) in SeqAn 1.4.x
+   handling of truncated sequence files. Also revamp exceptions
+   * khmer/_khmermodule.cc: Use new/updated exceptions handling malformed
+   FASTA/Q files.
+   * tests/test_read_parsers.py: add a test of parsing of truncated fastq
+   files
+
 2015-04-03  Luiz Irber  <irberlui@msu.edu>
 
    * lib/hllcounter.cc: Use for loop instead of transform on merge method,

--- a/khmer/_khmermodule.cc
+++ b/khmer/_khmermodule.cc
@@ -368,9 +368,6 @@ _ReadPairIterator_iternext(khmer_ReadPairIterator_Object * myself)
 
     ReadPair    the_read_pair;
     bool    stop_iteration      = false;
-    bool    unknown_pair_reading_mode   = false;
-    bool    invalid_read_pair       = false;
-    bool    stream_read_error = false;
     const char * value_error_what = NULL;
     const char * io_error_what = NULL;
 

--- a/lib/read_parsers.cc
+++ b/lib/read_parsers.cc
@@ -58,7 +58,19 @@ void SeqAnParser::imprint_next_read(Read &the_read)
         ret = seqan::readRecord(the_read.name, the_read.sequence,
                                 the_read.quality, _private->stream);
         if (ret == 0) {
+            if (_num_reads == 0 && the_read.quality.length() != 0) {
+                _have_qualities = true;
+            }
             _num_reads++;
+        }
+        if (the_read.sequence.length() == 0) {
+            throw InvalidRead("Sequence is empty");
+        }
+        if (_have_qualities) {
+            if (the_read.sequence.length() != the_read.quality.length()) {
+                throw InvalidRead("Sequence and quality lengths differ");
+            }
+
         }
     }
     __asm__ __volatile__ ("" ::: "memory");
@@ -119,6 +131,7 @@ IParser(
         throw khmer_exception();
     }
     _num_reads = 0;
+    _have_qualities = false;
 }
 
 IParser::

--- a/lib/read_parsers.cc
+++ b/lib/read_parsers.cc
@@ -58,23 +58,22 @@ void SeqAnParser::imprint_next_read(Read &the_read)
         ret = seqan::readRecord(the_read.name, the_read.sequence,
                                 the_read.quality, _private->stream);
         if (ret == 0) {
-            if (_num_reads == 0 && the_read.quality.length() != 0) {
-                _have_qualities = true;
-            }
             _num_reads++;
-        }
-        if (the_read.sequence.length() == 0) {
-            throw InvalidRead("Sequence is empty");
-        }
-        if (_have_qualities) {
-            if (the_read.sequence.length() != the_read.quality.length()) {
-                throw InvalidRead("Sequence and quality lengths differ");
-            }
-
         }
     }
     __asm__ __volatile__ ("" ::: "memory");
     _private->seqan_spin_lock = 0;
+    if (_num_reads > 0 && the_read.quality.length() != 0) {
+        _have_qualities = true;
+    }
+    if (the_read.sequence.length() == 0) {
+        throw InvalidRead("Sequence is empty");
+    }
+    if (_have_qualities) {
+        if (the_read.sequence.length() != the_read.quality.length()) {
+            throw InvalidRead("Sequence and quality lengths differ");
+        }
+    }
     if (atEnd) {
         throw NoMoreReadsAvailable();
     }

--- a/lib/read_parsers.cc
+++ b/lib/read_parsers.cc
@@ -63,18 +63,19 @@ void SeqAnParser::imprint_next_read(Read &the_read)
     }
     __asm__ __volatile__ ("" ::: "memory");
     _private->seqan_spin_lock = 0;
-    if (_num_reads > 0 && the_read.quality.length() != 0) {
-        _have_qualities = true;
-    }
-    if (the_read.sequence.length() == 0) {
-        throw InvalidRead("Sequence is empty");
-    }
-    if (_have_qualities) {
-        if (the_read.sequence.length() != the_read.quality.length()) {
-            throw InvalidRead("Sequence and quality lengths differ");
+    if (!atEnd) {
+        if (_num_reads > 0 && the_read.quality.length() != 0) {
+            _have_qualities = true;
         }
-    }
-    if (atEnd) {
+        if (the_read.sequence.length() == 0) {
+            throw InvalidRead("Sequence is empty");
+        }
+        if (_have_qualities) {
+            if (the_read.sequence.length() != the_read.quality.length()) {
+                throw InvalidRead("Sequence and quality lengths differ");
+            }
+        }
+    } else {
         throw NoMoreReadsAvailable();
     }
     if (ret != 0) {

--- a/lib/read_parsers.cc
+++ b/lib/read_parsers.cc
@@ -68,10 +68,16 @@ void SeqAnParser::imprint_next_read(Read &the_read)
             _have_qualities = true;
         }
         if (the_read.sequence.length() == 0) {
+            // We decrement the number of reads we've got, as the last one is
+            // invlaid
+            __sync_fetch_and_sub(&_num_reads, 1);
             throw InvalidRead("Sequence is empty");
         }
         if (_have_qualities) {
             if (the_read.sequence.length() != the_read.quality.length()) {
+                // We decrement the number of reads we've got, as the last one
+                // is invlaid
+                __sync_fetch_and_sub(&_num_reads, 1);
                 throw InvalidRead("Sequence and quality lengths differ");
             }
         }
@@ -79,6 +85,7 @@ void SeqAnParser::imprint_next_read(Read &the_read)
         throw NoMoreReadsAvailable();
     }
     if (ret != 0) {
+        // No need to decrement _num_reads, as we didn't increment it above
         throw StreamReadError();
     }
 }

--- a/lib/read_parsers.hh
+++ b/lib/read_parsers.hh
@@ -25,7 +25,7 @@ struct NoMoreReadsAvailable : public  khmer_exception {
     explicit NoMoreReadsAvailable(const char *msg) :
         khmer_exception(msg) {}
     NoMoreReadsAvailable() :
-        khmer_exception("No more reads available in this file") {}
+        khmer_exception("No more reads available in this stream.") {}
 };
 
 struct InvalidRead : public  khmer_exception {
@@ -39,14 +39,14 @@ struct UnknownPairReadingMode : public  khmer_exception {
     explicit UnknownPairReadingMode(const char *msg) :
         khmer_exception(msg) {}
     UnknownPairReadingMode() :
-        khmer_exception("Unknown pair reading mode") {}
+        khmer_exception("Unknown pair reading mode supplied.") {}
 };
 
 struct InvalidReadPair : public  khmer_exception {
     explicit InvalidReadPair(const char *msg) :
         khmer_exception(msg) {}
     InvalidReadPair() :
-        khmer_exception("Invalid read pair") {}
+        khmer_exception("Invalid read pair detected.") {}
 };
 
 struct Read {

--- a/lib/read_parsers.hh
+++ b/lib/read_parsers.hh
@@ -105,7 +105,7 @@ struct IParser {
 
     size_t		    get_num_reads()
     {
-	    return _num_reads;
+        return _num_reads;
     }
 
 protected:

--- a/lib/read_parsers.hh
+++ b/lib/read_parsers.hh
@@ -24,29 +24,29 @@ namespace read_parsers
 struct NoMoreReadsAvailable : public  khmer_exception {
     explicit NoMoreReadsAvailable(const char *msg) :
         khmer_exception(msg) {}
-    explicit NoMoreReadsAvailable() :
-        khmer_exception("No More Reads Available In This File") {}
+    NoMoreReadsAvailable() :
+        khmer_exception("No more reads available in this file") {}
 };
 
 struct InvalidRead : public  khmer_exception {
     explicit InvalidRead(const char *msg) :
         khmer_exception(msg) {}
-    explicit InvalidRead() :
-        khmer_exception("Invalid Read") {}
+    InvalidRead() :
+        khmer_exception("Invalid read") {}
 };
 
 struct UnknownPairReadingMode : public  khmer_exception {
     explicit UnknownPairReadingMode(const char *msg) :
         khmer_exception(msg) {}
-    explicit UnknownPairReadingMode() :
-        khmer_exception("Unknown Pair Reading Mode") {}
+    UnknownPairReadingMode() :
+        khmer_exception("Unknown pair reading mode") {}
 };
 
 struct InvalidReadPair : public  khmer_exception {
     explicit InvalidReadPair(const char *msg) :
         khmer_exception(msg) {}
-    explicit InvalidReadPair() :
-        khmer_exception("Invalid Read Pair") {}
+    InvalidReadPair() :
+        khmer_exception("Invalid read pair") {}
 };
 
 struct Read {

--- a/lib/read_parsers.hh
+++ b/lib/read_parsers.hh
@@ -22,12 +22,31 @@ namespace read_parsers
 {
 
 struct NoMoreReadsAvailable : public  khmer_exception {
+    explicit NoMoreReadsAvailable(const char *msg) :
+        khmer_exception(msg) {}
+    explicit NoMoreReadsAvailable() :
+        khmer_exception("No More Reads Available In This File") {}
+};
+
+struct InvalidRead : public  khmer_exception {
+    explicit InvalidRead(const char *msg) :
+        khmer_exception(msg) {}
+    explicit InvalidRead() :
+        khmer_exception("Invalid Read") {}
 };
 
 struct UnknownPairReadingMode : public  khmer_exception {
+    explicit UnknownPairReadingMode(const char *msg) :
+        khmer_exception(msg) {}
+    explicit UnknownPairReadingMode() :
+        khmer_exception("Unknown Pair Reading Mode") {}
 };
 
 struct InvalidReadPair : public  khmer_exception {
+    explicit InvalidReadPair(const char *msg) :
+        khmer_exception(msg) {}
+    explicit InvalidReadPair() :
+        khmer_exception("Invalid Read Pair") {}
 };
 
 struct Read {
@@ -92,6 +111,7 @@ struct IParser {
 protected:
 
     size_t		_num_reads;
+    bool        _have_qualities;
     regex_t		_re_read_2_nosub;
     regex_t		_re_read_1;
     regex_t		_re_read_2;

--- a/tests/test-data/truncated.fq
+++ b/tests/test-data/truncated.fq
@@ -1,0 +1,5 @@
+@1:1:1:1:1 1:N:0:NNNNN
+CAGGCGCCCA
++
+][aaX__aa[
+@

--- a/tests/test_read_parsers.py
+++ b/tests/test_read_parsers.py
@@ -247,6 +247,17 @@ def test_casava_1_8_pair_mating():
     t2.join()
 
 
+def test_read_truncated():
+
+    rparser = ReadParser(utils.get_test_data("truncated.fq"))
+    try:
+        for read in rparser:
+            pass
+        assert 0, "No exception raised on a truncated file"
+    except IOError as err:
+        assert "Sequence is empty" in str(err), str(err)
+
+
 def test_iterator_identities():
 
     rparser = \

--- a/tests/test_read_parsers.py
+++ b/tests/test_read_parsers.py
@@ -77,6 +77,7 @@ def test_num_reads_threads():
 
     assert rparser.num_reads == 100
 
+
 def test_num_reads_truncated():
 
     n_reads = 0
@@ -87,7 +88,7 @@ def test_num_reads_truncated():
     except IOError as err:
         assert "Sequence is empty" in str(err), str(err)
     assert rparser.num_reads == 1, "%d valid reads in file, got %d" % (
-            n_reads, rparser.num_reads)
+        n_reads, rparser.num_reads)
 
 
 def test_gzip_decompression():

--- a/tests/test_read_parsers.py
+++ b/tests/test_read_parsers.py
@@ -77,6 +77,18 @@ def test_num_reads_threads():
 
     assert rparser.num_reads == 100
 
+def test_num_reads_truncated():
+
+    n_reads = 0
+    rparser = ReadParser(utils.get_test_data("truncated.fq"))
+    try:
+        for read in rparser:
+            n_reads += 1
+    except IOError as err:
+        assert "Sequence is empty" in str(err), str(err)
+    assert rparser.num_reads == 1, "%d valid reads in file, got %d" % (
+            n_reads, rparser.num_reads)
+
 
 def test_gzip_decompression():
     reads_count = 0


### PR DESCRIPTION
Half workaround, half bugfix

In #884, I noticed that truncated fastq files cause an empty read to be emitted from the parser. This throws an exception to work around this. Seqan fixes this in 2.0.



- [x] Is it mergeable?
- [x] Did it pass the tests?
- [x] If it introduces new functionality in scripts/ is it tested?
  Check for code coverage with `make clean diff-cover`
- [ ] Is it well formatted? Look at `make pep8`, `make diff_pylint_report`,
  `make cppcheck`, and `make doc` output. Use `make format` and manual
  fixing as needed.
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Is it documented in the ChangeLog?
  http://en.wikipedia.org/wiki/Changelog#Format
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?