### PR TITLE
split test for extract_long_sequences into test for fa and for fq

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2015-04-03  Jessica Mizzi  <mizzijes@msu.edu>
+
+   * tests/test_scripts.py: split test_extract_long_sequences into test_extract_long_sequences_fa and test_extract_long_sequences_fq
+
 2015-03-06  Titus Brown  <titus@idyll.org>
 
    * sandbox/{collect-reads.py,saturate-by-median.py}: update for 'force'

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -2165,7 +2165,8 @@ def test_extract_long_sequences_fa():
     assert countlines == 22, countlines
 
     names = [r.name for r in screed.open(fa_outfile, parse_description=False)]
-    assert "895:1:37:17593:9954 2::foo" in names
+    assert "895:1:37:17593:9954/1" in names
+    assert "895:1:37:17593:9954/2" in names
 
 
 def test_extract_long_sequences_fq():
@@ -2187,6 +2188,7 @@ def test_extract_long_sequences_fq():
 
     names = [r.name for r in screed.open(fq_outfile, parse_description=False)]
     assert "895:1:37:17593:9954 1::foo" in names
+    assert "895:1:37:17593:9954 2::foo" in names
 
 
 def test_sample_reads_randomly_S():

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -2147,36 +2147,46 @@ def test_fastq_to_fasta():
     assert "4 lines dropped" in err
 
 
-def test_extract_long_sequences():
+def test_extract_long_sequences_fa():
+
+    script = scriptpath('extract-long-sequences.py')
+    fa_infile = utils.get_temp_filename('test.fa')
+
+    shutil.copyfile(utils.get_test_data('paired-mixed.fa'), fa_infile)
+
+    fa_outfile = fa_infile + '.keep.fa'
+
+    in_dir_fa = os.path.dirname(fa_infile)
+
+    args = [fa_infile, '-l', '1-', '-o', fa_outfile]
+    (status, out, err) = utils.runscript(script, args, in_dir_fa)
+
+    countlines = sum(1 for line in open(fa_outfile))
+    assert countlines == 22, countlines
+
+    names = [r.name for r in screed.open(fa_outfile, parse_description=False)]
+    assert "895:1:37:17593:9954 2::foo" in names
+
+
+def test_extract_long_sequences_fq():
 
     script = scriptpath('extract-long-sequences.py')
     fq_infile = utils.get_temp_filename('test.fq')
-    fa_infile = utils.get_temp_filename('test.fa')
 
     shutil.copyfile(utils.get_test_data('paired-mixed.fq'), fq_infile)
-    shutil.copyfile(utils.get_test_data('paired-mixed.fa'), fa_infile)
 
     fq_outfile = fq_infile + '.keep.fq'
-    fa_outfile = fa_infile + '.keep.fa'
 
     in_dir_fq = os.path.dirname(fq_infile)
-    in_dir_fa = os.path.dirname(fa_infile)
 
     args = [fq_infile, '-l', '10', '-o', fq_outfile]
-    (status, out, err) = utils.runscript(script, args, in_dir_fa)
+    (status, out, err) = utils.runscript(script, args, in_dir_fq)
 
     countlines = sum(1 for line in open(fq_outfile))
     assert countlines == 44, countlines
 
     names = [r.name for r in screed.open(fq_outfile, parse_description=False)]
     assert "895:1:37:17593:9954 1::foo" in names
-    assert "895:1:37:17593:9954 2::foo" in names
-
-    args = [fa_infile, '-l', '10', '-o', fa_outfile]
-    (status, out, err) = utils.runscript(script, args, in_dir_fa)
-
-    countlines = sum(1 for line in open(fa_outfile))
-    assert countlines == 22, countlines
 
 
 def test_sample_reads_randomly_S():

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -2158,7 +2158,7 @@ def test_extract_long_sequences_fa():
 
     in_dir_fa = os.path.dirname(fa_infile)
 
-    args = [fa_infile, '-l', '1-', '-o', fa_outfile]
+    args = [fa_infile, '-l', '10', '-o', fa_outfile]
     (status, out, err) = utils.runscript(script, args, in_dir_fa)
 
     countlines = sum(1 for line in open(fa_outfile))


### PR DESCRIPTION
splitting test_extract_long_sequences into 2 tests specific to fasta and fastq formats as described in issue #825