### PR TITLE
Use for loop instead of transform

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2015-04-03  Luiz Irber  <irberlui@msu.edu>
+
+   * lib/hllcounter.cc: Use for loop instead of transform on merge method,
+   now works on C++11.
+
 2015-04-01  Luiz Irber  <irberlui@msu.edu>
 
    * third-party/smhasher/MurmurHash3.{cc,h}: remove unused code, fix warnings.

--- a/lib/hllcounter.cc
+++ b/lib/hllcounter.cc
@@ -455,13 +455,7 @@ bool HLLCounter::check_and_normalize_read(std::string &read) const
 
 void HLLCounter::merge(HLLCounter &other)
 {
-    std::transform(this->M.begin(), this->M.end(),
-                   other.M.begin(),
-                   this->M.begin(),
-                   std::max<int>);
-    /*
     for(unsigned int i=0; i < this->M.size(); ++i) {
         this->M[i] = std::max(other.M[i], this->M[i]);
     }
-    */
 }


### PR DESCRIPTION
HLL merge method tried to be fancy and use std::transform instead of a for loop. Turns out the semantics changed for C++11, so it didn't work. Now works on C++11, and is probably simpler to understand too.