### PR TITLE
added check_file_status() for input_table

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,11 +1,11 @@
+2015-04-13 Scott Fay <scott.a.fay@gmail.com>
+
+   * added checking of input_table by `check_file_status()`
+
 2015-04-13  David Lin
 
    * scripts/abundance-dist.py: disambiguate documentation for force and 
    squash options
-
-2015-04-13 Scott Fay <scott.a.fay@gmail.com>
-
-   * added checking of input_table by `check_file_status()`
 
 2015-04-13  Michael R. Crusoe
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2015-04-13 Scott Fay <scott.a.fay@gmail.com>
+
+   * added checking of input_table by `check_file_status()`
+
 2015-04-13  Michael R. Crusoe
 
    * README.rst,doc/index.rst: added link to gitter.im chat room

--- a/scripts/filter-abund.py
+++ b/scripts/filter-abund.py
@@ -76,16 +76,15 @@ def main():
     info('filter-abund.py', ['counting'])
     args = get_parser().parse_args()
 
-    counting_ht = args.input_table
+    check_file_status(args.input_table, args.force)
     infiles = args.input_filename
-
     for _ in infiles:
         check_file_status(_, args.force)
 
     check_space(infiles, args.force)
 
     print >>sys.stderr, 'loading hashtable'
-    htable = khmer.load_counting_hash(counting_ht)
+    htable = khmer.load_counting_hash(args.input_table)
     ksize = htable.ksize()
 
     print >>sys.stderr, "K:", ksize


### PR DESCRIPTION
Added file status checking `check_file_status()` for args.input_table in filter_abund.py
Not a documented issue, but found it while examining code for another issue.

- [x] Is it mergable?
- [x] Did it pass the tests?
- [x] If it introduces new functionality in scripts/ is it tested?
  Check for code coverage.
- [x] Is it well formatted? Look at `make pep8`, `make diff_pylint_report`,
  `make cppcheck`, and `make doc` output. Use `make format` and manual
  fixing as needed.
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Is it documented in the ChangeLog?
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?