### PR TITLE
Add pep257 targets to Makefile in preparation of docstrings cleanup.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ sphinx-contrib
 compile_commands.json
 .DS_Store
 pylint_report.txt
+pep8_report.txt
+pep257_report.txt

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2015-04-14  Andreas Härpfer  <ahaerpfer@gmail.com>
+
+   * */*.py: Make docstrings PEP 257 compliant.
+
 2015-04-13  Thomas Fenzl  <thomas.fenzl@gmx.net>
 
    * lib/{khmer_exception.hh,{counting,hashbits,hashtable,subset}.cc}: changed 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ CPPSOURCES=$(wildcard lib/*.cc lib/*.hh khmer/_khmermodule.cc)
 PYSOURCES=$(wildcard khmer/*.py scripts/*.py)
 SOURCES=$(PYSOURCES) $(CPPSOURCES) setup.py
 DEVPKGS=sphinxcontrib-autoprogram pep8==1.5.7 diff_cover \
-autopep8 pylint coverage gcovr nose screed
+autopep8 pylint coverage gcovr nose screed pep257
 
 GCOVRURL=git+https://github.com/nschum/gcovr.git@never-executed-branches
 VERSION=$(shell git describe --tags --dirty | sed s/v//)
@@ -109,6 +109,17 @@ pep8_report.txt: $(PYSOURCES) $(wildcard tests/*.py)
 
 diff_pep8_report: pep8_report.txt
 	diff-quality --violations=pep8 pep8_report.txt
+
+## pep257      : check Python code style
+pep257: $(PYSOURCES) $(wildcard tests/*.py)
+	pep257 setup.py khmer/ scripts/ tests/ || true
+
+pep257_report.txt: $(PYSOURCES) $(wildcard tests/*.py)
+	pep257 setup.py khmer/ scripts/ tests/ \
+		> pep257_report.txt 2>&1 || true
+
+diff_pep257_report: pep257_report.txt
+	diff-quality --violations=pep8 pep257_report.txt
 
 ## astyle      : fix most C++ code indentation and formatting
 astyle: $(CPPSOURCES)

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,8 @@ diff_pep8_report: pep8_report.txt
 
 ## pep257      : check Python code style
 pep257: $(PYSOURCES) $(wildcard tests/*.py)
-	pep257 setup.py khmer/ scripts/ tests/ || true
+	pep257 --ignore=D100,D101,D102,D103 \
+		setup.py khmer/ scripts/ tests/ || true
 
 pep257_report.txt: $(PYSOURCES) $(wildcard tests/*.py)
 	pep257 setup.py khmer/ scripts/ tests/ \

--- a/khmer/__init__.py
+++ b/khmer/__init__.py
@@ -4,9 +4,7 @@
 # the three-clause BSD license; see doc/LICENSE.txt.
 # Contact: khmer-project@idyll.org
 #
-"""
-This is khmer; please see http://khmer.readthedocs.org/.
-"""
+"""This is khmer; please see http://khmer.readthedocs.org/."""
 
 from khmer._khmer import CountingHash
 from khmer._khmer import LabelHash as _LabelHash
@@ -182,7 +180,7 @@ def calc_expected_collisions(hashtable):
 
 
 def is_prime(number):
-    '''Checks if a number is prime.'''
+    """Check if a number is prime."""
     if number < 2:
         return False
     if number == 2:
@@ -196,13 +194,13 @@ def is_prime(number):
 
 
 def get_n_primes_near_x(number, target):
-    ''' Step backwards until a number of primes (other than 2) have been
+    """Step backwards until a number of primes (other than 2) have been
     found that are smaller than the target and return them.
 
     Keyword arguments:
     number -- the number of primes to find
     target -- the number to step backwards from
-    '''
+    """
     primes = []
     i = target - 1
     if i % 2 == 0:
@@ -215,13 +213,13 @@ def get_n_primes_near_x(number, target):
 
 
 def get_n_primes_above_x(number, target):
-    '''Step forwards until a number of primes (other than 2) have been
+    """Step forwards until a number of primes (other than 2) have been
     found that are smaller than the target and return them.
 
     Keyword arguments:
     number -- the number of primes to find
     target -- the number to step forwards from
-    '''
+    """
     primes = []
     i = target + 1
     if i % 2 == 0:
@@ -232,12 +230,11 @@ def get_n_primes_above_x(number, target):
         i += 2
     return primes
 
-'''
-Expose the cpython objects with __new__ implementations.
-These constructors add the functionality provided by the existing
-factory methods to the constructors defined over in cpython land.
-Additional functionality can be added to these classes as appropriate.
-'''
+
+# Expose the cpython objects with __new__ implementations.
+# These constructors add the functionality provided by the existing
+# factory methods to the constructors defined over in cpython land.
+# Additional functionality can be added to these classes as appropriate.
 
 
 class LabelHash(_LabelHash):
@@ -259,7 +256,9 @@ class Hashbits(_Hashbits):
 
 
 class HLLCounter(_HLLCounter):
-    """
+
+    """HyperLogLog counter.
+
     A HyperLogLog counter is a probabilistic data structure specialized on
     cardinality estimation.
     There is a precision/memory consumption trade-off: error rate determines

--- a/khmer/__init__.py
+++ b/khmer/__init__.py
@@ -194,7 +194,9 @@ def is_prime(number):
 
 
 def get_n_primes_near_x(number, target):
-    """Step backwards until a number of primes (other than 2) have been
+    """Backward-find primes smaller than target.
+
+    Step backwards until a number of primes (other than 2) have been
     found that are smaller than the target and return them.
 
     Keyword arguments:
@@ -213,7 +215,9 @@ def get_n_primes_near_x(number, target):
 
 
 def get_n_primes_above_x(number, target):
-    """Step forwards until a number of primes (other than 2) have been
+    """Forward-find primes smaller than target.
+
+    Step forwards until a number of primes (other than 2) have been
     found that are smaller than the target and return them.
 
     Keyword arguments:

--- a/khmer/kfile.py
+++ b/khmer/kfile.py
@@ -5,9 +5,7 @@
 # Contact: khmer-project@idyll.org
 #
 
-'''
-File handling/checking utilities for command-line scripts.
-'''
+"""File handling/checking utilities for command-line scripts."""
 
 import os
 import sys
@@ -16,9 +14,11 @@ from stat import S_ISBLK, S_ISFIFO
 
 
 def check_file_status(file_path, force):
-    """Check the status of the file; if the file is empty or doesn't exist
-    AND if the file is NOT a fifo/block/named pipe then a warning is printed
-    and sys.exit(1) is called
+    """Check the status of the file.
+
+    If the file is empty or doesn't exist AND if the file is NOT a
+    fifo/block/named pipe then a warning is printed and sys.exit(1) is
+    called
     """
     mode = None
 
@@ -54,7 +54,7 @@ def check_file_status(file_path, force):
 
 
 def check_file_writable(file_path):
-    """Returns if file_path is writable, exits out if it's not"""
+    """Return if file_path is writable, exit out if it's not."""
     try:
         file_obj = open(file_path, "a")
     except IOError as error:
@@ -70,11 +70,11 @@ def check_file_writable(file_path):
 
 
 def check_space(in_files, force, _testhook_free_space=None):
-    """
-    Estimate size of input files passed, then calculate
-    disk space available. Exit if insufficient disk space,
-    """
+    """Check for available disk space.
 
+    Estimate size of input files passed, then calculate disk space
+    available and exit if disk space is insufficient.
+    """
     # Get disk free space in Bytes assuming non superuser
     # and assuming all inFiles are in same disk
     in_file = in_files[0]
@@ -110,9 +110,7 @@ def check_space(in_files, force, _testhook_free_space=None):
 
 
 def check_space_for_hashtable(hash_size, force, _testhook_free_space=None):
-    """
-    Check we have enough size to write a hash table
-    """
+    """Check we have enough size to write a hash table."""
     cwd = os.getcwd()
     dir_path = os.path.dirname(os.path.realpath(cwd))
     target = os.statvfs(dir_path)
@@ -136,11 +134,12 @@ def check_space_for_hashtable(hash_size, force, _testhook_free_space=None):
 
 
 def check_valid_file_exists(in_files):
-    """
+    """Warn if input files are empty or missing.
+
     In a scenario where we expect multiple input files and
     are OK with some of them being empty or non-existent,
     this check warns to stderr if any input file is empty
-    or non-existent
+    or non-existent.
     """
     for in_file in in_files:
         if os.path.exists(in_file):

--- a/khmer/khmer_args.py
+++ b/khmer/khmer_args.py
@@ -28,7 +28,6 @@ def build_hash_args(descr=None, epilog=None):
     """Build an argparse.ArgumentParser with arguments for hash* based
     scripts and return it.
     """
-
     parser = argparse.ArgumentParser(
         description=descr, epilog=epilog,
         formatter_class=ComboFormatter)
@@ -67,10 +66,7 @@ def build_counting_args(descr=None, epilog=None):
 
 
 def build_hashbits_args(descr=None, epilog=None):
-    """Build an argparse.ArgumentParser with arguments for hashbits based
-    scripts and return it.
-    """
-
+    """Build ArgumentParser with args. for hashbits based scripts."""
     parser = build_hash_args(descr=descr, epilog=epilog)
     parser.hashtype = 'hashbits'
 
@@ -125,11 +121,9 @@ will be ignored.'''.format(hashfile=values))
 
 
 def report_on_config(args, hashtype='counting'):
+    """Summariz the configuration produced by the command-line arguments
+    made available by this module.
     """
-        Summarizes the configuration produced by the command-line arguments
-        made available by this module.
-    """
-
     from khmer.utils import print_error
 
     if args.quiet:
@@ -166,6 +160,7 @@ def report_on_config(args, hashtype='counting'):
 
 
 def add_threading_args(parser):
+    """Add option for threading to options parser."""
     parser.add_argument('--threads', '-T', default=DEFAULT_N_THREADS, type=int,
                         help='Number of simultaneous threads to execute')
 
@@ -184,6 +179,7 @@ _algorithms = {
 
 
 def info(scriptname, algorithm_list=None):
+    """Print version and project info to stderr."""
     import khmer
 
     sys.stderr.write("\n")

--- a/khmer/khmer_args.py
+++ b/khmer/khmer_args.py
@@ -25,9 +25,7 @@ class ComboFormatter(argparse.ArgumentDefaultsHelpFormatter,
 
 
 def build_hash_args(descr=None, epilog=None):
-    """Build an argparse.ArgumentParser with arguments for hash* based
-    scripts and return it.
-    """
+    """Build an ArgumentParser with args for bloom filter based scripts."""
     parser = argparse.ArgumentParser(
         description=descr, epilog=epilog,
         formatter_class=ComboFormatter)
@@ -55,10 +53,7 @@ def build_hash_args(descr=None, epilog=None):
 
 
 def build_counting_args(descr=None, epilog=None):
-    """Build an argparse.ArgumentParser with arguments for counting_hash
-    based scripts and return it.
-    """
-
+    """Build an ArgumentParser with args for counting_hash based scripts."""
     parser = build_hash_args(descr=descr, epilog=epilog)
     parser.hashtype = 'counting'
 
@@ -66,7 +61,7 @@ def build_counting_args(descr=None, epilog=None):
 
 
 def build_hashbits_args(descr=None, epilog=None):
-    """Build ArgumentParser with args. for hashbits based scripts."""
+    """Build an ArgumentParser with args for hashbits based scripts."""
     parser = build_hash_args(descr=descr, epilog=epilog)
     parser.hashtype = 'hashbits'
 
@@ -121,7 +116,9 @@ will be ignored.'''.format(hashfile=values))
 
 
 def report_on_config(args, hashtype='counting'):
-    """Summariz the configuration produced by the command-line arguments
+    """Print out configuration.
+
+    Summarize the configuration produced by the command-line arguments
     made available by this module.
     """
     from khmer.utils import print_error

--- a/khmer/thread_utils.py
+++ b/khmer/thread_utils.py
@@ -4,9 +4,8 @@
 # the three-clause BSD license; see doc/LICENSE.txt.
 # Contact: khmer-project@idyll.org
 #
-"""
-Utilities for dealing with multithreaded processing of short reads.
-"""
+"""Utilities for dealing with multithreaded processing of short reads."""
+
 import threading
 import Queue
 import sys
@@ -17,6 +16,7 @@ DEFAULT_GROUPSIZE = 100
 
 
 def verbose_loader(filename):
+    """Screed iterator that additionally prints progress info to stderr."""
     screed_iter = screed.open(filename, parse_description=False)
     for n, record in enumerate(screed_iter):
         if n % 100000 == 0:

--- a/khmer/utils.py
+++ b/khmer/utils.py
@@ -9,18 +9,16 @@
 
 
 def print_error(msg):
-    """
-    Prints the given message to 'stderr'.
-    """
-
+    """Print the given message to 'stderr'."""
     import sys
 
     print >>sys.stderr, msg
 
 
 def check_is_pair(record1, record2):
-    """
-    Checks to see if the two sequence records are left and right pairs
+    """Check if the two sequence records belong to the same fragment.
+
+    In an matching pair the records are left and right pairs
     of each other, respectively.  Returns True or False as appropriate.
 
     Handles both Casava formats: seq/1 and seq/2, and 'seq::... 1::...'
@@ -53,9 +51,9 @@ def check_is_pair(record1, record2):
 
 
 def check_is_left(name):
-    """
-    Checks if the name belongs to a 'left' sequence (/1).  Returns True or
-    False.
+    """Check if the name belongs to a 'left' sequence (/1).
+
+    Returns True or False.
 
     Handles both Casava formats: seq/1 and 'seq::... 1::...'
     """
@@ -70,9 +68,9 @@ def check_is_left(name):
 
 
 def check_is_right(name):
-    """
-    Checks if the name belongs to a 'right' sequence (/2).  Returns True or
-    False.
+    """Check if the name belongs to a 'right' sequence (/2).
+
+    Returns True or False.
 
     Handles both Casava formats: seq/2 and 'seq::... 2::...'
     """
@@ -87,7 +85,8 @@ def check_is_right(name):
 
 
 def broken_paired_reader(screed_iter, min_length=None, force_single=False):
-    """
+    """Read pairs from a stream.
+    
     A generator that yields singletons and pairs from a stream of FASTA/FASTQ
     records (yielded by 'screed_iter').  Yields (n, is_pair, r1, r2) where
     'r2' is None if is_pair is False.
@@ -138,9 +137,7 @@ def broken_paired_reader(screed_iter, min_length=None, force_single=False):
 
 
 def write_record(record, fileobj):
-    """
-    Writes sequence record to 'fileobj' in FASTA/FASTQ format.
-    """
+    """Write sequence record to 'fileobj' in FASTA/FASTQ format."""
     if hasattr(record, 'quality'):
         fileobj.write(
             '@{name}\n{seq}\n'
@@ -154,9 +151,7 @@ def write_record(record, fileobj):
 
 
 def write_record_pair(read1, read2, fileobj):
-    """
-    Writes pair of sequence records to 'fileobj' in FASTA/FASTQ format.
-    """
+    """Write a pair of sequence records to 'fileobj' in FASTA/FASTQ format."""
     if hasattr(read1, 'quality'):
         assert hasattr(read2, 'quality')
     write_record(read1, fileobj)

--- a/khmer/utils.py
+++ b/khmer/utils.py
@@ -86,7 +86,7 @@ def check_is_right(name):
 
 def broken_paired_reader(screed_iter, min_length=None, force_single=False):
     """Read pairs from a stream.
-    
+
     A generator that yields singletons and pairs from a stream of FASTA/FASTQ
     records (yielded by 'screed_iter').  Yields (n, is_pair, r1, r2) where
     'r2' is None if is_pair is False.

--- a/scripts/abundance-dist-single.py
+++ b/scripts/abundance-dist-single.py
@@ -7,10 +7,11 @@
 #
 # pylint: disable=invalid-name,missing-docstring
 """
-Produce the k-mer abundance distribution for the given file, without
-loading a prebuilt k-mer counting table.
+Produce the k-mer abundance distribution for the given file.
 
 % python scripts/abundance-dist-single.py <data> <histout>
+
+The script does not load a prebuilt k-mer counting table.
 
 Use '-h' for parameter help.
 """

--- a/scripts/count-median.py
+++ b/scripts/count-median.py
@@ -7,9 +7,11 @@
 #
 # pylint: disable=missing-docstring,invalid-name
 """
-Count the median/avg k-mer abundance for each sequence in the input file,
-based on the k-mer counts in the given k-mer counting table.  Can be used to
-estimate expression levels (mRNAseq) or coverage (genomic/metagenomic).
+Count the median/avg k-mer abundance for each sequence in the input file.
+
+The abundance is based on the k-mer counts in the given k-mer counting
+table.  Can be used to estimate expression levels (mRNAseq) or coverage
+(genomic/metagenomic).
 
 % scripts/count-median.py <htname> <input seqs> <output counts>
 

--- a/scripts/count-overlap.py
+++ b/scripts/count-overlap.py
@@ -7,8 +7,9 @@
 #
 # pylint: disable=missing-docstring,invalid-name
 """
-Count the overlap k-mers, which are the k-mers appearing in two sequence
-datasets.
+Count the overlap k-mers.
+
+Overlap k-mers are those appearing in two sequence datasets.
 
 usage: count-overlap_cpp.py [-h] [-q] [--ksize KSIZE] [--n_tables N_HASHES]
         [--tablesize HASHSIZE]
@@ -16,7 +17,6 @@ usage: count-overlap_cpp.py [-h] [-q] [--ksize KSIZE] [--n_tables N_HASHES]
         result
 
 Use '-h' for parameter help.
-
 """
 import sys
 import csv

--- a/scripts/extract-long-sequences.py
+++ b/scripts/extract-long-sequences.py
@@ -8,6 +8,8 @@
 # pylint: disable=invalid-name,missing-docstring
 
 """
+Extract long sequences.
+
 Write out lines of FASTQ and FASTA files that exceed an argument-specified
 length.
 

--- a/scripts/extract-paired-reads.py
+++ b/scripts/extract-paired-reads.py
@@ -7,6 +7,8 @@
 #
 # pylint: disable=invalid-name,missing-docstring
 """
+Split up pairs and singletons.
+
 Take a file containing a mixture of interleaved and orphaned reads, and
 extract them into separate files (.pe and .se).
 

--- a/scripts/filter-abund-single.py
+++ b/scripts/filter-abund-single.py
@@ -7,6 +7,8 @@
 #
 # pylint: disable=missing-docstring,invalid-name
 """
+Sequence trimming by abundance w/o counting table.
+
 Trim sequences at k-mers of the given abundance for the given file,
 without loading a prebuilt counting table.  Output sequences will be
 placed in 'infile.abundfilt'.

--- a/scripts/filter-abund.py
+++ b/scripts/filter-abund.py
@@ -7,6 +7,8 @@
 #
 # pylint: disable=missing-docstring,invalid-name
 """
+Sequence trimming by abundance using counting table.
+
 Trim sequences at k-mers of the given abundance, based on the given counting
 hash table.  Output sequences will be placed in 'infile.abundfilt'.
 

--- a/scripts/filter-stoptags.py
+++ b/scripts/filter-stoptags.py
@@ -7,6 +7,8 @@
 #
 # pylint: disable=invalid-name,missing-docstring
 """
+Sequence trimming using stoptags.
+
 Trim sequences at k-mers in the given stoptags file.  Output sequences
 will be placed in 'infile.stopfilt'.
 

--- a/scripts/find-knots.py
+++ b/scripts/find-knots.py
@@ -7,8 +7,9 @@
 #
 # pylint: disable=invalid-name,missing-docstring
 """
-Find highly-connected k-mers and output them in a .stoptags file, for use
-in partitioning.
+Find highly-connected k-mers.
+
+k-mers are output into a .stoptags file, for later use in partitioning.
 
 % python scripts/find-knots.py <base>
 """

--- a/scripts/galaxy/gedlab.py
+++ b/scripts/galaxy/gedlab.py
@@ -1,6 +1,4 @@
-"""
-k-mer count and presence
-"""
+"""k-mer count and presence."""
 
 from galaxy.datatypes.binary import Binary
 

--- a/scripts/interleave-reads.py
+++ b/scripts/interleave-reads.py
@@ -7,6 +7,8 @@
 #
 # pylint: disable=invalid-name,missing-docstring
 """
+Interleave left and right reads.
+
 Take two files containing left & right reads from a paired-end sequencing run,
 and interleave them.
 

--- a/scripts/normalize-by-median.py
+++ b/scripts/normalize-by-median.py
@@ -7,6 +7,8 @@
 #
 # pylint: disable=invalid-name,missing-docstring
 """
+Eliminate surplus reads.
+
 Eliminate reads with median k-mer abundance higher than
 DESIRED_COVERAGE.  Output sequences will be placed in 'infile.keep'.
 

--- a/scripts/readstats.py
+++ b/scripts/readstats.py
@@ -44,8 +44,7 @@ def get_parser():
 
 
 def main():
-    "Main function - run when executed as a script."
-
+    """Main function - run when executed as a script."""
     parser = get_parser()
     args = parser.parse_args()
 

--- a/scripts/sample-reads-randomly.py
+++ b/scripts/sample-reads-randomly.py
@@ -7,6 +7,8 @@
 #
 # pylint: disable=invalid-name,missing-docstring
 """
+Subsample sequences from multiple files.
+
 Take a list of files containing sequences, and subsample 100,000 sequences (-N)
 uniformly, using reservoir sampling.  Stop after first 100m sequences (-M).
 By default take one subsample, but take -S samples if specified.

--- a/scripts/split-paired-reads.py
+++ b/scripts/split-paired-reads.py
@@ -7,6 +7,8 @@
 #
 # pylint: disable=invalid-name,missing-docstring
 """
+De-interleave a file.
+
 Take an interleaved set of reads (/1 and /2), and extract them into separate
 files (.1 and .2).
 

--- a/scripts/trim-low-abund.py
+++ b/scripts/trim-low-abund.py
@@ -7,6 +7,7 @@
 #
 """
 Trim sequences at k-mers of the given abundance, using a streaming algorithm.
+
 Output sequences will be placed in 'infile.abundtrim'.
 
 % python scripts/trim-low-abund.py [ <data1> [ <data2> [ ... ] ] ]

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 # Copyright (C) Michigan State University, 2009-2015. It is licensed under
 # the three-clause BSD license; see doc/LICENSE.txt.
 # Contact: khmer-project@idyll.org
-""" Setup for khmer project. """
+"""Setup for khmer project."""
 
 import ez_setup
 
@@ -50,6 +50,7 @@ os.environ['OPT'] = " ".join(
 
 
 def check_for_openmp():
+    """Check for OpenMP support."""
     # Create a temporary directory
     tmpdir = tempfile.mkdtemp()
     curdir = os.getcwd()
@@ -203,6 +204,7 @@ class KhmerBuildExt(_build_ext):  # pylint: disable=R0904
     """
 
     def run(self):
+        """Run extension builder."""
         if "%x" % sys.maxsize != '7fffffffffffffff':
             raise DistutilsPlatformError("%s require 64-bit operating system" %
                                          SETUP_METADATA["packages"])
@@ -233,13 +235,13 @@ _DISTUTILS_REINIT = Distribution.reinitialize_command
 
 
 def reinitialize_command(self, command, reinit_subcommands):
-    '''
-    Monkeypatch distutils.Distribution.reinitialize_command() to match behavior
-    of Distribution.get_command_obj()
+    """Monkeypatch distutils.Distribution.reinitialize_command().
 
+    It's supposed to match the behavior of Distribution.get_command_obj()
     This fixes issues with 'pip install -e' and './setup.py nosetests' not
-    respecting the setup.cfg configuration directives for the build_ext command
-    '''
+    respecting the setup.cfg configuration directives for the build_ext
+    command.
+    """
     cmd_obj = _DISTUTILS_REINIT(self, command, reinit_subcommands)
     options = self.command_options.get(command)
     if options:

--- a/setup.py
+++ b/setup.py
@@ -235,7 +235,7 @@ _DISTUTILS_REINIT = Distribution.reinitialize_command
 
 
 def reinitialize_command(self, command, reinit_subcommands):
-    """Monkeypatch distutils.Distribution.reinitialize_command().
+    """Monkeypatch the original version from distutils.
 
     It's supposed to match the behavior of Distribution.get_command_obj()
     This fixes issues with 'pip install -e' and './setup.py nosetests' not

--- a/tests/khmer_tst_utils.py
+++ b/tests/khmer_tst_utils.py
@@ -75,7 +75,8 @@ def _runscript(scriptname, sandbox=False):
 
 def runscript(scriptname, args, in_directory=None,
               fail_ok=False, sandbox=False):
-    """
+    """Run a Python script using exec().
+
     Run the given Python script, with the given args, in the given directory,
     using 'execfile'.
     """
@@ -124,11 +125,11 @@ def runscript(scriptname, args, in_directory=None,
 
 def runscriptredirect(scriptname, args, stdinfilename, in_directory=None,
                       fail_ok=False, sandbox=False):
-    """
+    """Run a Python script using subprocess().
+
     Run the given Python script, with the given args, in the given directory,
     using 'subprocess'.
     """
-
     cwd = os.getcwd()
 
     status = -1


### PR DESCRIPTION
- [x] Is it mergeable?
- [x] Did it pass the tests?
- [x] If it introduces new functionality in scripts/ is it tested?
  Check for code coverage with `make clean diff-cover`
- [x] Is it well formatted? Look at `make pep8`, `make diff_pylint_report`,
  `make cppcheck`, and `make doc` output. Use `make format` and manual
  fixing as needed.
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Is it documented in the ChangeLog?
  http://en.wikipedia.org/wiki/Changelog#Format
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
