### PR TITLE
added Copyright queston to commit checklist

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,11 +1,11 @@
-2015-04-14  Andreas Härpfer  <ahaerpfer@gmail.com>
-
-   * */*.py: Make docstrings PEP 257 compliant.
-
 2015-04-14  Sarah Guermond  <sarah.guermond@gmail.com>
 
    * doc/dev/coding-guidelines-and-review.rst: added copyright question
    to commit checklist.
+
+2015-04-14  Andreas Härpfer  <ahaerpfer@gmail.com>
+
+   * */*.py: Make docstrings PEP 257 compliant.
 
 2015-04-13  Thomas Fenzl  <thomas.fenzl@gmx.net>
 

--- a/doc/dev/coding-guidelines-and-review.rst
+++ b/doc/dev/coding-guidelines-and-review.rst
@@ -72,7 +72,7 @@ ready for review::
      http://en.wikipedia.org/wiki/Changelog#Format
    - [ ] Was a spellchecker run on the source code and documentation after
      changes were made?
-   - [ ] Is the Copyright up to date?
+   - [ ] Is the Copyright year up to date?
 
 **Note** that after you submit the comment you can check and uncheck
 the individual boxes on the formatted comment; no need to put x or y

--- a/doc/dev/coding-guidelines-and-review.rst
+++ b/doc/dev/coding-guidelines-and-review.rst
@@ -72,6 +72,7 @@ ready for review::
      http://en.wikipedia.org/wiki/Changelog#Format
    - [ ] Was a spellchecker run on the source code and documentation after
      changes were made?
+   - [ ] Is the Copyright up to date?
 
 **Note** that after you submit the comment you can check and uncheck
 the individual boxes on the formatted comment; no need to put x or y


### PR DESCRIPTION
Fixed issue #937 

- [x] Is it mergeable?
- [x] Did it pass the tests?
- [x] If it introduces new functionality in scripts/ is it tested?
  Check for code coverage with `make clean diff-cover`
- [x] Is it well formatted? Look at `make pep8`, `make diff_pylint_report`,
  `make cppcheck`, and `make doc` output. Use `make format` and manual
  fixing as needed.
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Is it documented in the ChangeLog?
  http://en.wikipedia.org/wiki/Changelog#Format
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?