### PR TITLE
Fix issue #21:  Refactor Hash Size Warning Logic into Common Module

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2015-04-14 Susan Steinman <steinman.tutoring@gmail.com>
+   * khmer/{__init__.py},sandbox/{collect-reads,collect-variants,saturate-by-median},
+      scripts/{do-partition,filter-abund-single,load-graph,load-into-counting,
+      normalize-by-median,trim-low-abund}: pulled out check max collisions logic to init.
+   * khmer/tests/test_scripts.py: modified tests to account for new error message
+
+
 2015-04-13  Thomas Fenzl  <thomas.fenzl@gmx.net>
 
    * lib/{khmer_exception.hh,{counting,hashbits,hashtable,subset}.cc}: changed 
@@ -6,7 +13,7 @@
 2015-04-14  Michael R. Crusoe  <mcrusoe@msu.edu>
 
    * khmer/_khmermodule.cc: catch more exceptions
-   * tests/test_{sandbox_scripts,subset_graph}.py: make tests more resiliant
+   * tests/test_{sandbox_scripts,subset_graph}.py: make tests more resilient
 
 2015-04-14  Michael R. Crusoe  <mcrusoe@msu.edu>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,7 +7,6 @@
 2015-04-14  Josiah Seaman  <josiah@dnaskittle.com>
 
    * lib/{hashbits.cc}: changed: adding doxygen comments
->>>>>>> 6b55eb863185b97532a51d41ab17fdd90c1a3a2b
 
 2015-04-14  Sarah Guermond  <sarah.guermond@gmail.com>
 
@@ -17,7 +16,6 @@
 2015-04-14  Andreas Härpfer  <ahaerpfer@gmail.com>
 
    * */*.py: Make docstrings PEP 257 compliant.
->>>>>>> 42fb8c13b663cbeb5d1502ed8de63704547e2bda
 
 2015-04-13  Thomas Fenzl  <thomas.fenzl@gmx.net>
 

--- a/khmer/__init__.py
+++ b/khmer/__init__.py
@@ -36,6 +36,7 @@ from khmer._khmer import ReadParser  # sandbox/to-casava-1.8-fastq.py
 # tests/test_read_parsers.py,scripts/{filter-abund-single,load-graph}.py
 # scripts/{abundance-dist-single,load-into-counting}.py
 
+import sys
 
 from struct import pack, unpack
 
@@ -164,8 +165,9 @@ def extract_countinghash_info(filename):
         ht_type
 
 
-def calc_expected_collisions(hashtable):
+def calc_expected_collisions(hashtable, max_false_positive=.2, force=False):
     """Do a quick & dirty expected collision rate calculation on a hashtable.
+    Check to see that collision rate is within threshold.
 
     Keyword argument:
     hashtable: the hashtable object to inspect
@@ -177,6 +179,16 @@ def calc_expected_collisions(hashtable):
 
     fp_one = occupancy / min_size
     fp_all = fp_one ** n_ht
+ 
+    if fp_all > max_false_positive:
+        print >>sys.stderr, "**"
+        print >>sys.stderr, "** ERROR: the graph structure is too small for "
+        print >>sys.stderr, "this data set.  Increase k-mer presence table "
+        print >>sys.stderr, "size/num of tables."
+        print >>sys.stderr, "** Do not use these results!!"
+        print >>sys.stderr, "**"
+        if not force:
+            sys.exit(1)
 
     return fp_all
 

--- a/khmer/__init__.py
+++ b/khmer/__init__.py
@@ -165,7 +165,7 @@ def extract_countinghash_info(filename):
         ht_type
 
 
-def calc_expected_collisions(hashtable, max_false_positive=.2, force=False):
+def calc_expected_collisions(hashtable, force=False, max_false_pos=.2):
     """Do a quick & dirty expected collision rate calculation on a hashtable.
     Check to see that collision rate is within threshold.
 
@@ -179,8 +179,8 @@ def calc_expected_collisions(hashtable, max_false_positive=.2, force=False):
 
     fp_one = occupancy / min_size
     fp_all = fp_one ** n_ht
- 
-    if fp_all > max_false_positive:
+
+    if fp_all > max_false_pos:
         print >>sys.stderr, "**"
         print >>sys.stderr, "** ERROR: the graph structure is too small for "
         print >>sys.stderr, "this data set.  Increase k-mer presence table "

--- a/sandbox/collect-reads.py
+++ b/sandbox/collect-reads.py
@@ -130,7 +130,7 @@ def main():
     info_fp.write('through end: %s\n' % filenames[-1])
 
     # Change 0.2 only if you really grok it.  HINT: You don't.
-    fp_rate = khmer.calc_expected_collisions(htable, max_false_positive=.2, force=args.force)
+    fp_rate = khmer.calc_expected_collisions(htable, args.force, max_false_positive=.2)
     print 'fp rate estimated to be %1.3f' % fp_rate
     print >> info_fp, 'fp rate estimated to be %1.3f' % fp_rate
 

--- a/sandbox/collect-reads.py
+++ b/sandbox/collect-reads.py
@@ -130,7 +130,7 @@ def main():
     info_fp.write('through end: %s\n' % filenames[-1])
 
     # Change 0.2 only if you really grok it.  HINT: You don't.
-    fp_rate = khmer.calc_expected_collisions(htable, args.force, max_false_positive=.2)
+    fp_rate = khmer.calc_expected_collisions(htable, args.force, max_false_pos=.2)
     print 'fp rate estimated to be %1.3f' % fp_rate
     print >> info_fp, 'fp rate estimated to be %1.3f' % fp_rate
 

--- a/sandbox/collect-reads.py
+++ b/sandbox/collect-reads.py
@@ -130,16 +130,9 @@ def main():
     info_fp.write('through end: %s\n' % filenames[-1])
 
     # Change 0.2 only if you really grok it.  HINT: You don't.
-    fp_rate = khmer.calc_expected_collisions(htable)
+    fp_rate = khmer.calc_expected_collisions(htable, max_false_positive=.2, force=args.force)
     print 'fp rate estimated to be %1.3f' % fp_rate
     print >> info_fp, 'fp rate estimated to be %1.3f' % fp_rate
-
-    if fp_rate > 0.20:
-        print >> sys.stderr, "**"
-        print >> sys.stderr, ("** ERROR: the k-mer counting table is too small"
-                              " this data set.  Increase tablesize/# tables.")
-        print >> sys.stderr, "**"
-        sys.exit(1)
 
     print 'DONE.'
 

--- a/sandbox/collect-variants.py
+++ b/sandbox/collect-variants.py
@@ -144,16 +144,9 @@ def main():
         ht.save(args.savehash)
 
     # Change 0.2 only if you really grok it.  HINT: You don't.
-    fp_rate = khmer.calc_expected_collisions(ht)
+    fp_rate = khmer.calc_expected_collisions(ht, max_false_positive=.2, force=args.force)
     print 'fp rate estimated to be %1.3f' % fp_rate
 
-    if fp_rate > 0.20:
-        print >>sys.stderr, "**"
-        print >>sys.stderr, "** ERROR: the counting hash is too small for"
-        print >>sys.stderr, "** this data set.  Increase hashsize/num ht."
-        print >>sys.stderr, "**"
-        print >>sys.stderr, "** Do not use these results!!"
-        sys.exit(-1)
 
 if __name__ == '__main__':
     main()

--- a/sandbox/collect-variants.py
+++ b/sandbox/collect-variants.py
@@ -144,7 +144,7 @@ def main():
         ht.save(args.savehash)
 
     # Change 0.2 only if you really grok it.  HINT: You don't.
-    fp_rate = khmer.calc_expected_collisions(ht, max_false_positive=.2, force=args.force)
+    fp_rate = khmer.calc_expected_collisions(ht, args.force, max_false_positive=.2)
     print 'fp rate estimated to be %1.3f' % fp_rate
 
 

--- a/sandbox/collect-variants.py
+++ b/sandbox/collect-variants.py
@@ -144,7 +144,7 @@ def main():
         ht.save(args.savehash)
 
     # Change 0.2 only if you really grok it.  HINT: You don't.
-    fp_rate = khmer.calc_expected_collisions(ht, args.force, max_false_positive=.2)
+    fp_rate = khmer.calc_expected_collisions(ht, args.force, max_false_pos=.2)
     print 'fp rate estimated to be %1.3f' % fp_rate
 
 

--- a/sandbox/saturate-by-median.py
+++ b/sandbox/saturate-by-median.py
@@ -25,8 +25,6 @@ from khmer.kfile import (check_space, check_space_for_hashtable,
                          check_valid_file_exists)
 DEFAULT_DESIRED_COVERAGE = 1
 
-MAX_FALSE_POSITIVE_RATE = 0.8             # see Zhang et al.,
-# http://arxiv.org/abs/1309.2975
 
 # Iterate a collection in arbitrary batches
 # from: http://stackoverflow.com/questions/4628290/pairs-from-single-list
@@ -237,22 +235,15 @@ def main():  # pylint: disable=too-many-branches,too-many-statements
         print '...saving to', args.savetable
         htable.save(args.savetable)
 
-    fp_rate = khmer.calc_expected_collisions(htable)
+    # re: threshold, see Zhang et al.,
+    # http://arxiv.org/abs/1309.2975
+    fp_rate = khmer.calc_expected_collisions(htable, max_false_positive=.8, force=args.force)
     print 'fp rate estimated to be {fpr:1.3f}'.format(fpr=fp_rate)
 
     if args.force and len(corrupt_files) > 0:
         print >> sys.stderr, "** WARNING: Finished with errors!"
         print >> sys.stderr, "** IOErrors occurred in the following files:"
         print >> sys.stderr, "\t", " ".join(corrupt_files)
-
-    if fp_rate > MAX_FALSE_POSITIVE_RATE:
-        print >> sys.stderr, "**"
-        print >> sys.stderr, ("** ERROR: the k-mer counting table is too small"
-                              " for this data set.  Increase tablesize/# "
-                              "tables.")
-        print >> sys.stderr, "**"
-        print >> sys.stderr, "** Do not use these results!!"
-        sys.exit(1)
 
 if __name__ == '__main__':
     main()

--- a/sandbox/saturate-by-median.py
+++ b/sandbox/saturate-by-median.py
@@ -237,7 +237,7 @@ def main():  # pylint: disable=too-many-branches,too-many-statements
 
     # re: threshold, see Zhang et al.,
     # http://arxiv.org/abs/1309.2975
-    fp_rate = khmer.calc_expected_collisions(htable, max_false_positive=.8, force=args.force)
+    fp_rate = khmer.calc_expected_collisions(htable, args.force, max_false_pos=.8)
     print 'fp rate estimated to be {fpr:1.3f}'.format(fpr=fp_rate)
 
     if args.force and len(corrupt_files) > 0:

--- a/scripts/do-partition.py
+++ b/scripts/do-partition.py
@@ -131,16 +131,8 @@ def main():  # pylint: disable=too-many-locals,too-many-statements
         print >>sys.stderr, 'consuming input', filename
         htable.consume_fasta_and_tag(filename)
 
-    fp_rate = khmer.calc_expected_collisions(htable)
+    fp_rate = khmer.calc_expected_collisions(htable, max_false_positive=.15, force=args.force) # 0.18 is ACTUAL MAX. Do not change.
     print >>sys.stderr, 'fp rate estimated to be %1.3f' % fp_rate
-    if fp_rate > 0.15:          # 0.18 is ACTUAL MAX. Do not change.
-        print >> sys.stderr, "**"
-        print >> sys.stderr, ("** ERROR: the graph structure is too small for"
-                              " this data set.  Increase k-mer presence table "
-                              "size/num of tables.")
-        print >> sys.stderr, "**"
-        if not args.force:
-            sys.exit(1)
 
     # partition-graph
 

--- a/scripts/do-partition.py
+++ b/scripts/do-partition.py
@@ -131,7 +131,9 @@ def main():  # pylint: disable=too-many-locals,too-many-statements
         print >>sys.stderr, 'consuming input', filename
         htable.consume_fasta_and_tag(filename)
 
-    fp_rate = khmer.calc_expected_collisions(htable, max_false_positive=.15, force=args.force) # 0.18 is ACTUAL MAX. Do not change.
+    # 0.18 is ACTUAL MAX. Do not change.
+    fp_rate = \
+        khmer.calc_expected_collisions(htable, args.force, max_false_pos=.15)
     print >>sys.stderr, 'fp rate estimated to be %1.3f' % fp_rate
 
     # partition-graph

--- a/scripts/filter-abund-single.py
+++ b/scripts/filter-abund-single.py
@@ -95,7 +95,7 @@ def main():
         print >> sys.stderr, 'Total number of unique k-mers: {0}'.format(
             htable.n_unique_kmers())
 
-    fp_rate = khmer.calc_expected_collisions(htable, force=args.force)
+    fp_rate = khmer.calc_expected_collisions(htable, args.force)
     print >>sys.stderr, 'fp rate estimated to be %1.3f' % fp_rate
 
     # now, trim.

--- a/scripts/filter-abund-single.py
+++ b/scripts/filter-abund-single.py
@@ -95,7 +95,7 @@ def main():
         print >> sys.stderr, 'Total number of unique k-mers: {0}'.format(
             htable.n_unique_kmers())
 
-    fp_rate = khmer.calc_expected_collisions(htable)
+    fp_rate = khmer.calc_expected_collisions(htable, force=args.force)
     print >>sys.stderr, 'fp rate estimated to be %1.3f' % fp_rate
 
     # now, trim.

--- a/scripts/load-graph.py
+++ b/scripts/load-graph.py
@@ -103,7 +103,10 @@ def main():
     info_fp = open(base + '.info', 'w')
     info_fp.write('%d unique k-mers' % htable.n_unique_kmers())
 
-    fp_rate = khmer.calc_expected_collisions(htable, max_false_positive=.15, force=args.force)  # 0.18 is ACTUAL MAX. Do not change.
+    fp_rate = \
+        khmer.calc_expected_collisions(htable, args.force, max_false_pos=.15)
+    # 0.18 is ACTUAL MAX. Do not change.
+
     print >>sys.stderr, 'fp rate estimated to be %1.3f' % fp_rate
     if args.write_fp_rate:
         print >> info_fp, \

--- a/scripts/load-graph.py
+++ b/scripts/load-graph.py
@@ -103,19 +103,11 @@ def main():
     info_fp = open(base + '.info', 'w')
     info_fp.write('%d unique k-mers' % htable.n_unique_kmers())
 
-    fp_rate = khmer.calc_expected_collisions(htable)
+    fp_rate = khmer.calc_expected_collisions(htable, max_false_positive=.15, force=args.force)  # 0.18 is ACTUAL MAX. Do not change.
     print >>sys.stderr, 'fp rate estimated to be %1.3f' % fp_rate
     if args.write_fp_rate:
         print >> info_fp, \
             '\nfalse positive rate estimated to be %1.3f' % fp_rate
-
-    if fp_rate > 0.15:          # 0.18 is ACTUAL MAX. Do not change.
-        print >> sys.stderr, "**"
-        print >> sys.stderr, ("** ERROR: the graph structure is too small for "
-                              "this data set. Increase table size/# tables.")
-        print >> sys.stderr, "**"
-        if not args.force:
-            sys.exit(1)
 
     print >> sys.stderr, 'wrote to', base + '.info and', base + '.pt'
     if not args.no_build_tagset:

--- a/scripts/load-into-counting.py
+++ b/scripts/load-into-counting.py
@@ -136,7 +136,9 @@ def main():
     print >>sys.stderr, 'saving', base
     htable.save(base)
 
-    fp_rate = khmer.calc_expected_collisions(htable, max_false_positive=.2, force=args.force)  # Change 0.2 only if you really grok it.  HINT: You don't.
+    # Change max_false_pos=0.2 only if you really grok it. HINT: You don't
+    fp_rate = \
+        khmer.calc_expected_collisions(htable, args.force, max_false_pos=.2)
 
     with open(base + '.info', 'a') as info_fp:
         print >> info_fp, 'fp rate estimated to be %1.3f\n' % fp_rate

--- a/scripts/load-into-counting.py
+++ b/scripts/load-into-counting.py
@@ -136,7 +136,7 @@ def main():
     print >>sys.stderr, 'saving', base
     htable.save(base)
 
-    fp_rate = khmer.calc_expected_collisions(htable)
+    fp_rate = khmer.calc_expected_collisions(htable, max_false_positive=.2, force=args.force)  # Change 0.2 only if you really grok it.  HINT: You don't.
 
     with open(base + '.info', 'a') as info_fp:
         print >> info_fp, 'fp rate estimated to be %1.3f\n' % fp_rate
@@ -163,14 +163,6 @@ def main():
                     fls=";".join(filenames)))
 
     print >> sys.stderr, 'fp rate estimated to be %1.3f' % fp_rate
-
-    # Change 0.2 only if you really grok it.  HINT: You don't.
-    if fp_rate > 0.20:
-        print >> sys.stderr, "**"
-        print >> sys.stderr, "** ERROR: the k-mer counting table is too small",
-        print >> sys.stderr, "for this data set. Increase tablesize/# tables."
-        print >> sys.stderr, "**"
-        sys.exit(1)
 
     print >>sys.stderr, 'DONE.'
     print >>sys.stderr, 'wrote to:', base + '.info'

--- a/scripts/normalize-by-median.py
+++ b/scripts/normalize-by-median.py
@@ -316,7 +316,10 @@ file for one of the input files will be generated.)" % filename
         print '...saving to', args.savetable
         htable.save(args.savetable)
 
-    fp_rate = khmer.calc_expected_collisions(htable, max_false_positive=.8, force=args.force) # see Zhang et al., http://arxiv.org/abs/1309.2975
+    fp_rate = \
+        khmer.calc_expected_collisions(htable, args.force, max_false_pos=.8)
+    # for max_false_pos see Zhang et al., http://arxiv.org/abs/1309.2975
+
     print >> sys.stderr, \
         'fp rate estimated to be {fpr:1.3f}'.format(fpr=fp_rate)
 

--- a/scripts/normalize-by-median.py
+++ b/scripts/normalize-by-median.py
@@ -29,9 +29,6 @@ from khmer.kfile import (check_space, check_space_for_hashtable,
 from khmer.utils import write_record, check_is_pair
 DEFAULT_DESIRED_COVERAGE = 10
 
-MAX_FALSE_POSITIVE_RATE = 0.8             # see Zhang et al.,
-# http://arxiv.org/abs/1309.2975
-
 # Iterate a collection in arbitrary batches
 # from: http://stackoverflow.com/questions/4628290/pairs-from-single-list
 
@@ -319,7 +316,7 @@ file for one of the input files will be generated.)" % filename
         print '...saving to', args.savetable
         htable.save(args.savetable)
 
-    fp_rate = khmer.calc_expected_collisions(htable)
+    fp_rate = khmer.calc_expected_collisions(htable, max_false_positive=.8, force=args.force) # see Zhang et al., http://arxiv.org/abs/1309.2975
     print >> sys.stderr, \
         'fp rate estimated to be {fpr:1.3f}'.format(fpr=fp_rate)
 
@@ -327,16 +324,6 @@ file for one of the input files will be generated.)" % filename
         print >> sys.stderr, "** WARNING: Finished with errors!"
         print >> sys.stderr, "** IOErrors occurred in the following files:"
         print >> sys.stderr, "\t", " ".join(corrupt_files)
-
-    if fp_rate > MAX_FALSE_POSITIVE_RATE:
-        print >> sys.stderr, "**"
-        print >> sys.stderr, ("** ERROR: the k-mer counting table is too small"
-                              " for this data set. Increase tablesize/# "
-                              "tables.")
-        print >> sys.stderr, "**"
-        print >> sys.stderr, "** Do not use these results!!"
-        if not args.force:
-            sys.exit(1)
 
 if __name__ == '__main__':
     main()

--- a/scripts/trim-low-abund.py
+++ b/scripts/trim-low-abund.py
@@ -31,9 +31,6 @@ from khmer.kfile import (check_space, check_space_for_hashtable,
 DEFAULT_NORMALIZE_LIMIT = 20
 DEFAULT_CUTOFF = 2
 
-# see Zhang et al., http://arxiv.org/abs/1309.2975
-MAX_FALSE_POSITIVE_RATE = 0.8
-
 
 def trim_record(read, trim_at):
     new_read = _screed_record_dict()
@@ -308,18 +305,10 @@ def main():
         print 'skipped %d reads/%d bases because of low coverage' % \
               (skipped_n, skipped_bp)
 
-    fp_rate = khmer.calc_expected_collisions(ct)
+    fp_rate = khmer.calc_expected_collisions(ct, max_false_positive=.8, force=args.force) # see Zhang et al., http://arxiv.org/abs/1309.2975
     print >>sys.stderr, \
         'fp rate estimated to be {fpr:1.3f}'.format(fpr=fp_rate)
 
-    if fp_rate > MAX_FALSE_POSITIVE_RATE:
-        print >> sys.stderr, "**"
-        print >> sys.stderr, ("** ERROR: the k-mer counting table is too small"
-                              " for this data set. Increase tablesize/# "
-                              "tables.")
-        print >> sys.stderr, "**"
-        print >> sys.stderr, "** Do not use these results!!"
-        sys.exit(1)
 
     print 'output in *.abundtrim'
 

--- a/scripts/trim-low-abund.py
+++ b/scripts/trim-low-abund.py
@@ -305,10 +305,11 @@ def main():
         print 'skipped %d reads/%d bases because of low coverage' % \
               (skipped_n, skipped_bp)
 
-    fp_rate = khmer.calc_expected_collisions(ct, max_false_positive=.8, force=args.force) # see Zhang et al., http://arxiv.org/abs/1309.2975
+    fp_rate = \
+        khmer.calc_expected_collisions(ct, args.force, max_false_pos=.8)
+    # for max_false_pos see Zhang et al., http://arxiv.org/abs/1309.2975
     print >>sys.stderr, \
         'fp rate estimated to be {fpr:1.3f}'.format(fpr=fp_rate)
-
 
     print 'output in *.abundtrim'
 

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -788,7 +788,6 @@ def test_normalize_by_median_fpr():
     (status, out, err) = utils.runscript(script, args, in_dir, fail_ok=True)
 
     assert os.path.exists(infile + '.keep')
-    #assert 'fp rate estimated to be' in err, err
     assert '** ERROR: the graph structure is too small' in err, err
 
 

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -788,8 +788,8 @@ def test_normalize_by_median_fpr():
     (status, out, err) = utils.runscript(script, args, in_dir, fail_ok=True)
 
     assert os.path.exists(infile + '.keep')
-    assert 'fp rate estimated to be' in err, err
-    assert '** ERROR: the k-mer counting table is too small' in err, err
+    #assert 'fp rate estimated to be' in err, err
+    assert '** ERROR: the graph structure is too small' in err, err
 
 
 def write_by_chunks(infile, outfile, CHUNKSIZE=8192):
@@ -2770,7 +2770,7 @@ def test_trim_low_abund_highfpr():
 
     assert code == 1
     print out
-    assert "ERROR: the k-mer counting table is too small" in err
+    assert '** ERROR: the graph structure is too small' in err, err
 
 
 def test_trim_low_abund_trimtest():


### PR DESCRIPTION
pull out error handling for too many collisions (table too small) into._init__.

Update tests to accommodate.

In filter abund, no threshold for max collisions listed--defaults to .2
Default is force=False. Force allowed in all places.

- [x] Is it mergeable?
- [x] Did it pass the tests?
- [x] If it introduces new functionality in scripts/ is it tested?
  Check for code coverage with `make clean diff-cover`
- [x] Is it well formatted? Look at `make pep8`, `make diff_pylint_report`,
  `make cppcheck`, and `make doc` output. Use `make format` and manual
  fixing as needed.
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Is it documented in the ChangeLog?
  http://en.wikipedia.org/wiki/Changelog#Format
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?