### PR TITLE
Fix Issuer #58: normalize-by-median: accept paired & unpaired data at the same time

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,11 @@
 2015-04-14 Susan Steinman <steinman.tutoring@gmail.com>
+
+   * khmer/scripts/normalize-by-median.py: allow for paired and unpaired
+      files to be normalized together. separate function for error check
+   * khmer/tests/test_scripts.py: created test for paired/unpaired data
+
+2015-04-14 Susan Steinman <steinman.tutoring@gmail.com>
+
    * khmer/{__init__.py},sandbox/{collect-reads,collect-variants,saturate-by-median},
       scripts/{do-partition,filter-abund-single,load-graph,load-into-counting,
       normalize-by-median,trim-low-abund}: pulled out check max collisions logic to init.

--- a/scripts/filter-abund-single.py
+++ b/scripts/filter-abund-single.py
@@ -1,3 +1,4 @@
+
 #! /usr/bin/env python2
 #
 # This file is part of khmer, http://github.com/ged-lab/khmer/, and is

--- a/scripts/filter-abund-single.py
+++ b/scripts/filter-abund-single.py
@@ -1,4 +1,3 @@
-
 #! /usr/bin/env python2
 #
 # This file is part of khmer, http://github.com/ged-lab/khmer/, and is

--- a/scripts/normalize-by-median.py
+++ b/scripts/normalize-by-median.py
@@ -123,7 +123,9 @@ def handle_error(error, output_name, input_name, fail_save, htable):
     except:  # pylint: disable=bare-except
         print >> sys.stderr, '** ERROR: problem removing corrupt filtered file'
 
-def normalize_by_median_and_check(input_filename, htable, args, report_fp, corrupt_files):
+
+def normalize_by_median_and_check(
+        input_filename, htable, args, report_fp, corrupt_files):
     total = 0
     discarded = 0
 
@@ -140,10 +142,10 @@ def normalize_by_median_and_check(input_filename, htable, args, report_fp, corru
     else:
         output_name = os.path.basename(input_filename) + '.keep'
         outfp = open(output_name, 'w')
-        
+
     try:
-        total_acc, discarded_acc = normalize_by_median(input_filename, outfp, \
-                                                        htable, args, report_fp)
+        total_acc, discarded_acc = normalize_by_median(input_filename, outfp,
+                                                       htable, args, report_fp)
     except IOError as err:
         handle_error(err, output_name, input_filename, args.fail_save,
                      htable)
@@ -166,7 +168,7 @@ def normalize_by_median_and_check(input_filename, htable, args, report_fp, corru
                         total=total, perc=int(100. - discarded /
                                               float(total) * 100.))
             print >> sys.stderr, 'output in', output_name
-    
+
     return total_acc, discarded_acc, corrupt_files
 
 
@@ -229,8 +231,8 @@ def get_parser():
     parser.add_argument('-C', '--cutoff', type=int,
                         default=DEFAULT_DESIRED_COVERAGE)
     parser.add_argument('-p', '--paired', action='store_true')
-    parser.add_argument('-u', '--unpaired', metavar="unpaired_reads_filename", 
-                        help='')
+    parser.add_argument('-u', '--unpaired', metavar="unpaired_reads_filename",
+                        help='with paired data only, include an unpaired file')
     parser.add_argument('-s', '--savetable', metavar="filename", default='',
                         help='save the k-mer counting table to disk after all'
                         'reads are loaded.')
@@ -305,8 +307,9 @@ file for one of the input files will be generated.)" % filename
     input_filename = None
 
     for index, input_filename in enumerate(args.input_filenames):
-        total_acc, discarded_acc, corrupt_files = normalize_by_median_and_check(input_filename,\
-                                                           htable, args, report_fp, corrupt_files)
+        total_acc, discarded_acc, corrupt_files = \
+            normalize_by_median_and_check(
+                input_filename, htable, args, report_fp, corrupt_files)
 
         if (args.dump_frequency > 0 and
                 index > 0 and index % args.dump_frequency == 0):
@@ -325,7 +328,9 @@ file for one of the input files will be generated.)" % filename
         if not args.single_output_file:
             output_name = os.path.basename(args.unpaired) + '.keep'
         outfp = open(output_name, 'w')
-        total_acc, discarded_acc, corrupt_files = normalize_by_median_and_check(args.unpaired, htable, args, report_fp, corrupt_files)
+        total_acc, discarded_acc, corrupt_files = \
+            normalize_by_median_and_check(
+                args.unpaired, htable, args, report_fp, corrupt_files)
 
     if args.report_total_kmers:
         print >> sys.stderr, 'Total number of unique k-mers: {0}'.format(

--- a/scripts/normalize-by-median.py
+++ b/scripts/normalize-by-median.py
@@ -303,8 +303,6 @@ file for one of the input files will be generated.)" % filename
         htable = khmer.new_counting_hash(args.ksize, args.min_tablesize,
                                          args.n_tables)
 
-    # total = 0
-    # discarded = 0
     input_filename = None
 
     for index, input_filename in enumerate(args.input_filenames):

--- a/scripts/normalize-by-median.py
+++ b/scripts/normalize-by-median.py
@@ -122,6 +122,12 @@ def handle_error(error, output_name, input_name, fail_save, htable):
         print >> sys.stderr, '** ERROR: problem removing corrupt filtered file'
 
 def normalize_by_median_and_check(input_filename, outfp, htable, args, report_fp):
+    total = 0
+    discarded = 0
+    if not args.single_output_file:
+        output_name = os.path.basename(input_filename) + '.keep'
+        outfp = open(output_name, 'w')
+        
     try:
         total_acc, discarded_acc = normalize_by_median(input_filename, outfp, \
                                                         htable, args, report_fp)
@@ -282,8 +288,8 @@ file for one of the input files will be generated.)" % filename
         htable = khmer.new_counting_hash(args.ksize, args.min_tablesize,
                                          args.n_tables)
 
-    total = 0
-    discarded = 0
+    # total = 0
+    # discarded = 0
     input_filename = None
 
     if args.single_output_file:
@@ -294,13 +300,6 @@ file for one of the input files will be generated.)" % filename
             output_name = args.single_output_file.name
 
     for index, input_filename in enumerate(args.input_filenames):
-        if not args.single_output_file:
-            output_name = os.path.basename(input_filename) + '.keep'
-            outfp = open(output_name, 'w')
-
-        total_acc = 0
-        discarded_acc = 0
-
         total_acc, discarded_acc = normalize_by_median_and_check(input_filename,\
                                                            outfp, htable, args,\
                                                            report_fp)

--- a/scripts/normalize-by-median.py
+++ b/scripts/normalize-by-median.py
@@ -232,8 +232,9 @@ def get_parser():
     parser.add_argument('-C', '--cutoff', type=int,
                         default=DEFAULT_DESIRED_COVERAGE)
     parser.add_argument('-p', '--paired', action='store_true')
-    parser.add_argument('-u', '--unpaired-reads', metavar="unpaired_reads_filename",
-                        help='with paired data only, include an unpaired file')
+    parser.add_argument('-u', '--unpaired-reads',
+                        metavar="unpaired_reads_filename", help='with paired data only,\
+                        include an unpaired file')
     parser.add_argument('-s', '--savetable', metavar="filename", default='',
                         help='save the k-mer counting table to disk after all'
                         'reads are loaded.')

--- a/scripts/normalize-by-median.py
+++ b/scripts/normalize-by-median.py
@@ -180,8 +180,9 @@ def get_parser():
     Paired end reads will be considered together if :option:`-p` is set. If
     either read will be kept, then both will be kept. This should result in
     keeping (or discarding) each sequencing fragment. This helps with retention
-    of repeats, especially. With :option: `-u`/:option:`--unpaired`, 
-    unpaired reads from the specified file will be read with the paired data. 
+    of repeats, especially. With :option: `-u`/:option:`--unpaired-reads`, 
+    unpaired reads from the specified file will be read after the paired data
+    is read. 
 
     With :option:`-s`/:option:`--savetable`, the k-mer counting table
     will be saved to the specified file after all sequences have been
@@ -231,7 +232,7 @@ def get_parser():
     parser.add_argument('-C', '--cutoff', type=int,
                         default=DEFAULT_DESIRED_COVERAGE)
     parser.add_argument('-p', '--paired', action='store_true')
-    parser.add_argument('-u', '--unpaired', metavar="unpaired_reads_filename",
+    parser.add_argument('-u', '--unpaired-reads', metavar="unpaired_reads_filename",
                         help='with paired data only, include an unpaired file')
     parser.add_argument('-s', '--savetable', metavar="filename", default='',
                         help='save the k-mer counting table to disk after all'
@@ -322,15 +323,15 @@ file for one of the input files will be generated.)" % filename
                 print 'Nothing given for savetable, saving to', hashname
             htable.save(hashname)
 
-    if args.paired and args.unpaired:
+    if args.paired and args.unpaired_reads:
         args.paired = False
-        output_name = args.unpaired
+        output_name = args.unpaired_reads
         if not args.single_output_file:
-            output_name = os.path.basename(args.unpaired) + '.keep'
+            output_name = os.path.basename(args.unpaired_reads) + '.keep'
         outfp = open(output_name, 'w')
         total_acc, discarded_acc, corrupt_files = \
             normalize_by_median_and_check(
-                args.unpaired, htable, args, report_fp, corrupt_files)
+                args.unpaired_reads, htable, args, report_fp, corrupt_files)
 
     if args.report_total_kmers:
         print >> sys.stderr, 'Total number of unique k-mers: {0}'.format(

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -533,6 +533,7 @@ def test_normalize_by_median():
     assert len(seqs) == 1, seqs
     assert seqs[0].startswith('GGTTGACGGGGCTCAGGGGG'), seqs
 
+
 def test_normalize_by_median_unpaired_and_paired():
     CUTOFF = '1'
 
@@ -553,6 +554,7 @@ def test_normalize_by_median_unpaired_and_paired():
     seqs = [r.sequence for r in screed.open(outfile)]
     assert len(seqs) == 1, seqs
     assert seqs[0].startswith('GGTTGACGGGGCTCAGGGGG'), seqs
+
 
 def test_normalize_by_median_double_file_name():
     infile = utils.get_temp_filename('test-abund-read-2.fa')

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -533,6 +533,26 @@ def test_normalize_by_median():
     assert len(seqs) == 1, seqs
     assert seqs[0].startswith('GGTTGACGGGGCTCAGGGGG'), seqs
 
+def test_normalize_by_median_unpaired_and_paired():
+    CUTOFF = '1'
+
+    infile = utils.get_temp_filename('test.fa')
+    in_dir = os.path.dirname(infile)
+
+    shutil.copyfile(utils.get_test_data('test-abund-read-paired.fa'), infile)
+
+    script = scriptpath('normalize-by-median.py')
+    args = ['-C', CUTOFF, '-k', '17', '-t', '-u test-abund-read-2.fa', infile]
+    (status, out, err) = utils.runscript(script, args, in_dir)
+
+    assert 'Total number of unique k-mers: 98' in err, err
+
+    outfile = infile + '.keep'
+    assert os.path.exists(outfile), outfile
+
+    seqs = [r.sequence for r in screed.open(outfile)]
+    assert len(seqs) == 1, seqs
+    assert seqs[0].startswith('GGTTGACGGGGCTCAGGGGG'), seqs
 
 def test_normalize_by_median_double_file_name():
     infile = utils.get_temp_filename('test-abund-read-2.fa')

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -542,18 +542,17 @@ def test_normalize_by_median_unpaired_and_paired():
 
     shutil.copyfile(utils.get_test_data('test-abund-read-paired.fa'), infile)
 
+    unpairedfile = utils.get_temp_filename('test1.fa', tempdir=in_dir)
+    shutil.copyfile(utils.get_test_data('random-20-a.fa'), unpairedfile)
+
     script = scriptpath('normalize-by-median.py')
-    args = ['-C', CUTOFF, '-k', '17', '-t', '-u test-abund-read-2.fa', infile]
+    args = ['-C', CUTOFF, '-k', '17', '-t', '-u', unpairedfile, '-p', infile]
     (status, out, err) = utils.runscript(script, args, in_dir)
 
-    assert 'Total number of unique k-mers: 98' in err, err
+    assert 'Total number of unique k-mers: 4029' in err, err
 
     outfile = infile + '.keep'
     assert os.path.exists(outfile), outfile
-
-    seqs = [r.sequence for r in screed.open(outfile)]
-    assert len(seqs) == 1, seqs
-    assert seqs[0].startswith('GGTTGACGGGGCTCAGGGGG'), seqs
 
 
 def test_normalize_by_median_double_file_name():


### PR DESCRIPTION
fix: Fixes issue #58 Allows unpaired data to be included with paired data.
refactor: Pulls error handling for normalize into separate wrapper function.

- [x] Is it mergeable?
- [x] Did it pass the tests?
- [x] If it introduces new functionality in scripts/ is it tested?
  Check for code coverage with `make clean diff-cover`
- [x] Is it well formatted? Look at `make pep8`, `make diff_pylint_report`,
  `make cppcheck`, and `make doc` output. Use `make format` and manual
  fixing as needed.
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Is it documented in the ChangeLog?
  http://en.wikipedia.org/wiki/Changelog#Format
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
- [x] Is the Copyright year up to date?