### PR TITLE
Added STDOUT streaming support for scripts/trim-low-abund.py

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -32,7 +32,6 @@
    max collisions logic to init.
    * khmer/tests/test_scripts.py: modified tests to account for new error
    message
->>>>>>> 192ae796ea8bb7c7ba0b84a1e1160547fba1d591
 
 2015-04-14  Josiah Seaman  <josiah@dnaskittle.com>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,3 @@
-
 2015-04-15  Sarah Guermond  <sarah.guermond@gmail.com>
 
    * scripts/trim-low-abund.py: implemented STDOUT output, redirected

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2015-04-15  Sarah Guermond  <sarah.guermond@gmail.com>
+
+   * doc/dev/scripts-and-sandbox.rst: added requirements for streaming I/O
+
 2015-04-14  Josiah Seaman  <josiah@dnaskittle.com>
 
    * lib/{hashbits.cc}: changed: adding doxygen comments

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 2015-04-15  Sarah Guermond  <sarah.guermond@gmail.com>
 
    * doc/dev/scripts-and-sandbox.rst: added requirements for streaming I/O
+   * scripts/trim-low-abund.py: added support for -o/--out
 
 2015-04-15  Michael R. Crusoe  <mcrusoe@msu.edu>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,22 +1,13 @@
 
 2015-04-15  Sarah Guermond  <sarah.guermond@gmail.com>
 
-   * scripts/trim-low-abund.py: fixed existing & new PEP 8 issues
+   * scripts/trim-low-abund.py: implemented STDOUT output, redirected
+   existing print statements to STDERR, fixed existing & new PEP 8 issues 
+   * tests/test_scripts.py: added test for above changes
 
 2014-04-15  Andreas Härpfer  <ahaerpfer@gmail.com>
 
    * doc/conf.py: disable Sphinx smart rendering
-
-2015-04-15  Sarah Guermond  <sarah.guermond@gmail.com>
-
-   * scripts/trim-low-abund.py: actually implemented STDOUT output, redirected
-   existing print statements to STDERR
-   * tests/test_scripts.py: added test for above changes
-
-2015-04-15  Sarah Guermond  <sarah.guermond@gmail.com>
-
-   * doc/dev/scripts-and-sandbox.rst: added requirements for streaming I/O
-   * scripts/trim-low-abund.py: added support for -o/--out
 
 2015-04-15  Michael R. Crusoe  <mcrusoe@msu.edu>
 

--- a/doc/dev/scripts-and-sandbox.rst
+++ b/doc/dev/scripts-and-sandbox.rst
@@ -114,5 +114,7 @@ development/PR checklist::
    - [ ] argparse help text exists, with an epilog docstring, with examples and options
    - [ ] standard command line options are implemented
    - [ ] version and citation information is output to STDERR (`khmer_args.info(...)`)
+   - [ ] support '-' (STDIN) as an input file, if appropriate
+   - [ ] support designation of an output file (including STDOUT), if appropriate
    - [ ] runtime diagnostic information (progress, etc.) is output to STDERR
    - [ ] script has been removed from sandbox/README.rst

--- a/scripts/normalize-by-median.py
+++ b/scripts/normalize-by-median.py
@@ -10,7 +10,8 @@
 Eliminate surplus reads.
 
 Eliminate reads with median k-mer abundance higher than
-DESIRED_COVERAGE.  Output sequences will be placed in 'infile.keep'.
+DESIRED_COVERAGE.  Output sequences will be placed in 'infile.keep', with the
+option to output to STDOUT.
 
 % python scripts/normalize-by-median.py [ -C <cutoff> ] <data1> <data2> ...
 

--- a/scripts/trim-low-abund.py
+++ b/scripts/trim-low-abund.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python2
 #
 # This file is part of khmer, http://github.com/ged-lab/khmer/, and is
-# Copyright (C) Michigan State University, 2009-2014. It is licensed under
+# Copyright (C) Michigan State University, 2009-2015. It is licensed under
 # the three-clause BSD license; see doc/LICENSE.txt.
 # Contact: khmer-project@idyll.org
 #

--- a/scripts/trim-low-abund.py
+++ b/scripts/trim-low-abund.py
@@ -21,6 +21,7 @@ import khmer
 import tempfile
 import shutil
 import textwrap
+import argparse
 
 from screed.screedRecord import _screed_record_dict
 from khmer.khmer_args import (build_counting_args, info, add_loadhash_args,
@@ -81,6 +82,14 @@ def get_parser():
     parser.add_argument('--normalize-to', '-Z', type=int,
                         help='base cutoff on this median k-mer abundance',
                         default=DEFAULT_NORMALIZE_LIMIT)
+
+    parser.add_argument('-o', '--out', metavar="filename",
+                        dest='single_output_file',
+                        type=argparse.FileType('w'),
+                        default=None, help='only output a single file with '
+                        'the specified filename; use a single dash "-" to '
+                        'specify that output should go to STDOUT (the '
+                        'terminal)')
 
     parser.add_argument('--variable-coverage', '-V', action='store_true',
                         default=False,


### PR DESCRIPTION
Fixed #946 - ONLY stdout, stdin should be supported once #960 is merged
Fixed #947 as well by accidental commit to same branch.

- [x] Is it mergeable?
- [x] Did it pass the tests?
- [x] If it introduces new functionality in scripts/ is it tested?
  Check for code coverage with `make clean diff-cover`
- [x] Is it well formatted? Look at `make pep8`, `make diff_pylint_report`,
  `make cppcheck`, and `make doc` output. Use `make format` and manual
  fixing as needed.
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Is it documented in the ChangeLog?
  http://en.wikipedia.org/wiki/Changelog#Format
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
- [x] Is the Copyright year up to date?