### PR TITLE
Fixes issue #964 Scripts/normalize-by-median.py Don't pass ArgParseObject to functions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2015-04-15  Susan Steinman  <steinman.tutoring@gmail.com>
+
+   * khmer/scripts/normalize-by-median.py: pass individual arg values to 
+      functions instead of ArgParse object
+
 2015-04-15  en zyme  <en_zyme@outlook.com>
 
    * khmer/khmer/kfile.py: check_file_status() -> check_input_files()

--- a/scripts/normalize-by-median.py
+++ b/scripts/normalize-by-median.py
@@ -43,14 +43,15 @@ def batchwise(coll, size):
 
 
 # pylint: disable=too-many-locals,too-many-branches
-def normalize_by_median(input_filename, outfp, htable, args, report_fp=None):
+def normalize_by_median(input_filename, outfp, htable, paired, cutoff,
+                        report_fp=None):
 
-    desired_coverage = args.cutoff
+    desired_coverage = cutoff
     ksize = htable.ksize()
 
     # In paired mode we read two records at a time
     batch_size = 1
-    if args.paired:
+    if paired:
         batch_size = 2
 
     index = -1
@@ -74,7 +75,7 @@ def normalize_by_median(input_filename, outfp, htable, args, report_fp=None):
 
         # If in paired mode, check that the reads are properly interleaved
 
-        if args.paired:
+        if paired:
             if not check_is_pair(batch[0], batch[1]):
                 raise IOError('Error: Improperly interleaved pairs \
                     {b0} {b1}'.format(b0=batch[0].name, b1=batch[1].name))
@@ -124,32 +125,33 @@ def handle_error(error, output_name, input_name, fail_save, htable):
         print >> sys.stderr, '** ERROR: problem removing corrupt filtered file'
 
 
-def normalize_by_median_and_check(
-        input_filename, htable, args, report_fp, corrupt_files):
+def normalize_by_median_and_check(input_filename, htable, single_output_file,
+                                  fail_save, paired, cutoff, force,
+                                  corrupt_files, report_fp=None):
     total = 0
     discarded = 0
 
     total_acc = None
     discarded_acc = None
 
-    if args.single_output_file:
-        if args.single_output_file is sys.stdout:
+    if single_output_file:
+        if single_output_file is sys.stdout:
             output_name = '/dev/stdout'
         else:
-            output_name = args.single_output_file.name
-        outfp = args.single_output_file
+            output_name = single_output_file.name
+        outfp = single_output_file
 
     else:
         output_name = os.path.basename(input_filename) + '.keep'
         outfp = open(output_name, 'w')
 
     try:
-        total_acc, discarded_acc = normalize_by_median(input_filename, outfp,
-                                                       htable, args, report_fp)
+        total_acc, discarded_acc = normalize_by_median(
+            input_filename, outfp, htable, paired, cutoff, report_fp=None)
     except IOError as err:
-        handle_error(err, output_name, input_filename, args.fail_save,
+        handle_error(err, output_name, input_filename, fail_save,
                      htable)
-        if not args.force:
+        if not force:
             print >> sys.stderr, '** Exiting!'
 
             sys.exit(1)
@@ -309,7 +311,9 @@ file for one of the input files will be generated.)" % filename
     for index, input_filename in enumerate(args.input_filenames):
         total_acc, discarded_acc, corrupt_files = \
             normalize_by_median_and_check(
-                input_filename, htable, args, report_fp, corrupt_files)
+                input_filename, htable, args.single_output_file,
+                args.fail_save, args.paired, args.cutoff, args.force,
+                corrupt_files, report_fp)
 
         if (args.dump_frequency > 0 and
                 index > 0 and index % args.dump_frequency == 0):
@@ -330,7 +334,9 @@ file for one of the input files will be generated.)" % filename
         outfp = open(output_name, 'w')
         total_acc, discarded_acc, corrupt_files = \
             normalize_by_median_and_check(
-                args.unpaired_reads, htable, args, report_fp, corrupt_files)
+                args.unpaired_reads, htable, args.single_output_file,
+                args.fail_save, args.paired, args.cutoff, args.force,
+                corrupt_files, report_fp)
 
     if args.report_total_kmers:
         print >> sys.stderr, 'Total number of unique k-mers: {0}'.format(


### PR DESCRIPTION
Fixes issue #964 

- [x] Is it mergable?
- [x] Did it pass the tests?
- [x] If it introduces new functionality in scripts/ is it tested?
  Check for code coverage.
- [x] Is it well formatted? Look at `make pep8`, `make diff_pylint_report`,
  `make cppcheck`, and `make doc` output. Use `make format` and manual
  fixing as needed.
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Is it documented in the ChangeLog?
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
