### PR TITLE
fixing docs to remind folks to make sure tests fail for the right reasons

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2015-04-15  Susan Steinman  <steinman.tutoring@gmail.com>
+
+   * khmer/tests/khmer_tst_utils.py,doc/dev/a-quick-guide-to-testing.rst
+      edited docstring and docs to remind people to make sure tests test
+      errors correctly
+
 2015-04-15  Sherine Awad  <sherine.awad@gmail.com>
 
    * sandbox/make-coverage.py: restored, was deleted by accident
@@ -6,10 +12,6 @@
 
    * khmer/tests/test_scripts.py: changed tests that use `runscript` with
       `fail_okay=True` to use asserts to confirm the correct failure type
-
-   * khmer/tests/khmer_tst_utils.py,doc/dev/a-quick-guide-to-testing.rst
-      edited docstring and docs to remind people to make sure tests test
-      errors correctly
 
 2015-04-15  Sarah Guermond  <sarah.guermond@gmail.com>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,10 @@
    * khmer/tests/test_scripts.py: changed tests that use `runscript` with
       `fail_okay=True` to use asserts to confirm the correct failure type
 
+   * khmer/tests/khmer_tst_utils.py,doc/dev/a-quick-guide-to-testing.rst
+      edited docstring and docs to remind people to make sure tests test
+      errors correctly
+
 2015-04-15  Sarah Guermond  <sarah.guermond@gmail.com>
 
    * doc/dev/getting-started.rst: clarified dev communication

--- a/doc/dev/a-quick-guide-to-testing.rst
+++ b/doc/dev/a-quick-guide-to-testing.rst
@@ -58,6 +58,11 @@ We suggest the following approach to writing tests for **new code**:
    your code -- if statements, fence-post bound errors, etc. -- and write
    tests that exercise those bits of code specifically.
 
+#. Make sure tests that expect a function call to fail (esp. with
+   fail_ok=True) are failing for the expected reason. Run the code from the
+   command line and see what the behavior is. For troubleshooting tests,
+   catch the error with try: ... except: or print err.
+
 For adding tests to **old code**, we recommend a mix of two approaches:
 
 #. use `"stupidity driven testing"

--- a/tests/khmer_tst_utils.py
+++ b/tests/khmer_tst_utils.py
@@ -79,6 +79,8 @@ def runscript(scriptname, args, in_directory=None,
 
     Run the given Python script, with the given args, in the given directory,
     using 'execfile'.
+
+    When using :attr:`fail_ok`=False in tests, specify the expected error.
     """
     sysargs = [scriptname]
     sysargs.extend(args)


### PR DESCRIPTION
in docstrings for khmer_tst_utils.py and in a-quick-guide-to-testing