### PR TITLE
Adding a test to extract_partitions: whitespace in fasta sequence header...

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2015-04-23  Lex Nederbragt  <lex.nederbragt@ibv.uio.no>
+
+   * tests/test_scripts.py: added a test for extract-partitions:
+   whitespace in fasta header.
+
 2015-04-21  Daniel Standage  <daniel.standage@gmail.com>
 
    * scripts/sample-reads-randomly.py: use broken paired reader to provide

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1321,7 +1321,8 @@ def test_extract_partitions_header_whitespace():
     dist = open(distfile).readline()
     assert dist.strip() == '1 11957 11957 11957'
 
-    parts = [r.name.split('\t')[1] for r in screed.open(partfile, parse_description=False)]
+    parts = [r.name.split('\t')[1]
+             for r in screed.open(partfile, parse_description=False)]
     assert len(parts) == 13538, len(parts)
     parts = set(parts)
     assert len(parts) == 12601, len(parts)

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1311,7 +1311,7 @@ def test_extract_partitions_header_whitespace():
     script = scriptpath('extract-partitions.py')
     args = ['extracted', partfile]
 
-    runscript(script, args, in_dir)
+    utils.runscript(script, args, in_dir)
 
     distfile = os.path.join(in_dir, 'extracted.dist')
     groupfile = os.path.join(in_dir, 'extracted.group0000.fa')

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1298,6 +1298,35 @@ def test_extract_partitions():
     assert len(parts) == 1, len(parts)
 
 
+def test_extract_partitions_header_whitespace():
+    seqfile = utils.get_test_data('test-overlap2.fa')
+    graphbase = _make_graph(
+        seqfile, do_partition=True, annotate_partitions=True)
+    in_dir = os.path.dirname(graphbase)
+
+    # get the final part file
+    partfile = os.path.join(in_dir, 'test-overlap2.fa.part')
+
+    # ok, now run extract-partitions.
+    script = scriptpath('extract-partitions.py')
+    args = ['extracted', partfile]
+
+    runscript(script, args, in_dir)
+
+    distfile = os.path.join(in_dir, 'extracted.dist')
+    groupfile = os.path.join(in_dir, 'extracted.group0000.fa')
+    assert os.path.exists(distfile)
+    assert os.path.exists(groupfile)
+
+    dist = open(distfile).readline()
+    assert dist.strip() == '1 11957 11957 11957'
+
+    parts = [r.name.split('\t')[1] for r in screed.open(partfile, parse_description=False)]
+    assert len(parts) == 13538, len(parts)
+    parts = set(parts)
+    assert len(parts) == 12601, len(parts)
+
+
 def test_extract_partitions_fq():
     seqfile = utils.get_test_data('random-20-a.fq')
     graphbase = _make_graph(


### PR DESCRIPTION
Addresses #175

- [x] Is it mergeable?
- [x] Did it pass the tests?
- [x] If it introduces new functionality in scripts/ is it tested?
  Check for code coverage with `make clean diff-cover`
- [x] Is it well formatted? Look at `make pep8`, `make diff_pylint_report`,
  `make cppcheck`, and `make doc` output. Use `make format` and manual
  fixing as needed.
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Is it documented in the ChangeLog?
  http://en.wikipedia.org/wiki/Changelog#Format
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
- [x] Is the Copyright year up to date?
