### PR TITLE
Add total number of reads to summary json/tsv

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2015-05-12  Kevin Murray  <spam@kdmurray.id.au>
+
+   * scripts/load-into-counting.py,test/test_scripts.py: Add the number of
+   reads processed to the machine readable output files of --summary-info.
+
 2015-05-11  Titus Brown  <titus@idyll.org>
 
    * scripts/sample-reads-randomly.py: fixed boundary error in

--- a/scripts/load-into-counting.py
+++ b/scripts/load-into-counting.py
@@ -158,16 +158,20 @@ def main():
                     "num_kmers": n_kmers,
                     "files": filenames,
                     "mrinfo_version": "0.2.0",
-                    "num_reads" : total_num_reads,
+                    "num_reads": total_num_reads,
                 }
                 json.dump(mr_data, mr_fh)
                 mr_fh.write('\n')
             elif mr_fmt == 'tsv':
                 mr_fh.write("ht_name\tfpr\tnum_kmers\tnum_reads\tfiles\n")
-                mr_fh.write(
-                        "{b:s}\t{fpr:1.3f}\t{k:d}\t{r:d}\t{fls:s}\n".format(
-                            b=os.path.basename(base), fpr=fp_rate, k=n_kmers,
-                            r=total_num_reads, fls=";".join(filenames)))
+                vals = [
+                    os.path.basename(base),
+                    "{:1.3f}".format(fp_rate),
+                    str(n_kmers),
+                    str(total_num_reads),
+                    ";".join(filenames),
+                ]
+                mr_fh.write("\t".join(vals) + "\n")
 
     print >> sys.stderr, 'fp rate estimated to be %1.3f' % fp_rate
 

--- a/scripts/load-into-counting.py
+++ b/scripts/load-into-counting.py
@@ -102,6 +102,8 @@ def main():
 
     filename = None
 
+    total_num_reads = 0
+
     for index, filename in enumerate(filenames):
 
         rparser = khmer.ReadParser(filename)
@@ -126,6 +128,7 @@ def main():
             htable.save(base)
         with open(base + '.info', 'a') as info_fh:
             print >> info_fh, 'through', filename
+        total_num_reads += rparser.num_reads
 
     n_kmers = htable.n_unique_kmers()
     if args.report_total_kmers:
@@ -154,15 +157,17 @@ def main():
                     "fpr": fp_rate,
                     "num_kmers": n_kmers,
                     "files": filenames,
-                    "mrinfo_version": "0.1.0",
+                    "mrinfo_version": "0.2.0",
+                    "num_reads" : total_num_reads,
                 }
                 json.dump(mr_data, mr_fh)
                 mr_fh.write('\n')
             elif mr_fmt == 'tsv':
-                mr_fh.write("ht_name\tfpr\tnum_kmers\tfiles\n")
-                mr_fh.write("{b:s}\t{fpr:1.3f}\t{k:d}\t{fls:s}\n".format(
-                    b=os.path.basename(base), fpr=fp_rate, k=n_kmers,
-                    fls=";".join(filenames)))
+                mr_fh.write("ht_name\tfpr\tnum_kmers\tnum_reads\tfiles\n")
+                mr_fh.write(
+                        "{b:s}\t{fpr:1.3f}\t{k:d}\t{r:d}\t{fls:s}\n".format(
+                            b=os.path.basename(base), fpr=fp_rate, k=n_kmers,
+                            r=total_num_reads, fls=";".join(filenames)))
 
     print >> sys.stderr, 'fp rate estimated to be %1.3f' % fp_rate
 

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -136,7 +136,8 @@ def test_load_into_counting_tsv():
         tabfile_lines = tabfh.readlines()
     assert len(tabfile_lines) == 2
     outbase = os.path.basename(outfile)
-    expected_tsv_line = '\t'.join([outbase, '0.000', '95', infile]) + '\n'
+    tsv = [outbase, '0.000', '95', '1001', infile]
+    expected_tsv_line = '\t'.join(tsv) + '\n'
     assert tabfile_lines[1] == expected_tsv_line, tabfile_lines
 
 
@@ -162,8 +163,9 @@ def test_load_into_counting_json():
         "files": [infile],
         "ht_name": outbase,
         "num_kmers": 95,
+        "num_reads": 1001,
         "fpr": 9.024965705097741e-11,
-        "mrinfo_version": "0.1.0",
+        "mrinfo_version": "0.2.0",
     }
 
     assert got_json == expected_json, got_json


### PR DESCRIPTION
This PR adds a count of the total number of reads to the machine readable outputs of `load-into-counting.py` (TSV/JSONs).

It takes the sum of the number of reads processed from the `khmer.ReadParser` object which is used for hashing across all read files.

I've also bumped the "mrinfo_version" tag in the json output to 0.2.0, FWIW.

Cheers,
K